### PR TITLE
Implement optional sheet ID parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const { lerPlanilhaGoogle } = require('./src/services/googleSheetService');
         }
     });
 
+    // Leitura da planilha utilizando o ID padrão definido no serviço
     const pedidos = await lerPlanilhaGoogle();
 
     for (const pedido of pedidos) {

--- a/lixeira/teste.js
+++ b/lixeira/teste.js
@@ -1,5 +1,6 @@
 const { lerPlanilhaGoogle } = require('./src/services/googleSheetService');
 
+// Caso deseje utilizar uma planilha diferente do ID padrão informe aqui
 const sheetId = 'SEU_ID_DA_PLANILHA';
 
 lerPlanilhaGoogle(sheetId).then(dados => {

--- a/src/controllers/envioController.js
+++ b/src/controllers/envioController.js
@@ -3,6 +3,7 @@ const { enviarMensagem } = require('../services/whatsappService');
 const mensagens = require('../utils/messages.json');
 
 async function enviarMensagens() {
+    // Sem parâmetro utilizamos o ID padrão definido em googleSheetService
     const pedidos = await lerPlanilhaGoogle();
 
     for (const pedido of pedidos) {

--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -1,7 +1,8 @@
 const { lerPlanilhaGoogle } = require('../services/googleSheetService');
 const mensagens = require('../utils/messages.json');
 
-// 🔥 Insira aqui o ID da sua planilha
+// ID da planilha utilizada para gerar as mensagens.
+// Caso não informado na chamada, será usado o ID padrão definido no serviço.
 const sheetId = '1O3NPxlgVQBcZ5W9NeFLQD717Ted9lHF5ZzM0eaS0aQ4';
 
 async function gerarMensagens(req, res) {

--- a/src/services/googleSheetService.js
+++ b/src/services/googleSheetService.js
@@ -1,13 +1,21 @@
 const { google } = require('googleapis');
 const path = require('path');
 
+// ID da planilha utilizado quando nenhum outro é informado nas chamadas
+const DEFAULT_SHEET_ID = '1O3NPxlgVQBcZ5W9NeFLQD717Ted9lHF5ZzM0eaS0aQ4';
+
 const auth = new google.auth.GoogleAuth({
     keyFile: path.join(__dirname, '../../credenciais.json'),
     scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
 });
 
-async function lerPlanilhaGoogle() {
-    const sheetId = '1O3NPxlgVQBcZ5W9NeFLQD717Ted9lHF5ZzM0eaS0aQ4'; // 🔥 Substitui aqui pelo ID da sua planilha
+/**
+ * Lê os dados de uma planilha do Google Sheets.
+ *
+ * @param {string} [sheetId=DEFAULT_SHEET_ID] - ID da planilha a ser lida.
+ *   Caso não informado, será utilizado o ID padrão definido no arquivo.
+ */
+async function lerPlanilhaGoogle(sheetId = DEFAULT_SHEET_ID) {
     const client = await auth.getClient();
     const sheets = google.sheets({ version: 'v4', auth: client });
 
@@ -43,8 +51,15 @@ async function lerPlanilhaGoogle() {
     }));
 }
 
-async function atualizarLinha(linha, coluna, valor) {
-  const sheetId = '1O3NPxlgVQBcZ5W9NeFLQD717Ted9lHF5ZzM0eaS0aQ4'; // ID da sua planilha
+/**
+ * Atualiza uma célula específica da planilha.
+ *
+ * @param {number} linha - Número da linha que será modificada.
+ * @param {string} coluna - Letra da coluna (ex: 'A').
+ * @param {string} valor - Valor a ser inserido na célula.
+ * @param {string} [sheetId=DEFAULT_SHEET_ID] - ID da planilha a ser atualizada.
+ */
+async function atualizarLinha(linha, coluna, valor, sheetId = DEFAULT_SHEET_ID) {
   const client = await auth.getClient();
   const sheets = google.sheets({ version: 'v4', auth: client });
 


### PR DESCRIPTION
## Summary
- allow specifying a sheet ID when reading/updating Google Sheets
- document optional parameter usage
- update controllers and examples to use the new API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684488e81ba48321ae42b45227cd18f6