### PR TITLE
Fix integration form cancel and validate backend

### DIFF
--- a/src/services/integrationService.js
+++ b/src/services/integrationService.js
@@ -1,11 +1,11 @@
 const crypto = require('crypto');
 
-function createIntegration(db, userId, platform, name) {
+function createIntegration(db, userId, platform, name, secretKey = null) {
     return new Promise((resolve, reject) => {
         const unique_path = crypto.randomBytes(16).toString('hex');
-        const sql = 'INSERT INTO integrations (user_id, platform, name, unique_path) VALUES (?, ?, ?, ?)';
+        const sql = 'INSERT INTO integrations (user_id, platform, name, unique_path, secret_key) VALUES (?, ?, ?, ?, ?)';
 
-        db.run(sql, [userId, platform, name, unique_path], function(err) {
+        db.run(sql, [userId, platform, name, unique_path, secretKey], function(err) {
             if (err) return reject(err);
             const newId = this.lastID;
             const baseUrl = process.env.APP_URL || `http://localhost:${process.env.PORT || 3000}`;


### PR DESCRIPTION
## Summary
- avoid pre-creating integrations in the browser
- allow saving or editing integrations with a single handler
- clear dataset when closing the integration form
- validate required fields in integration routes
- store secret key on creation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c5291ba5c832182955e4d171761d6