### PR TITLE
Fix user registration

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -17,6 +17,7 @@ exports.register = async (req, res) => {
         await subscriptionService.createSubscription(req.db, user.id, 1);
         res.status(201).json({ id: user.id, email: user.email, apiKey: user.api_key });
     } catch (err) {
+        console.error('Erro ao registrar usuario:', err);
         res.status(500).json({ error: 'Falha ao registrar usuário.' });
     }
 };

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -24,6 +24,8 @@ const initDb = () => {
                 `CREATE TABLE IF NOT EXISTS logs (id INTEGER PRIMARY KEY AUTOINCREMENT, cliente_id INTEGER, acao TEXT NOT NULL, detalhe TEXT, data_criacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP);`,
                 `CREATE TABLE IF NOT EXISTS automacoes (gatilho TEXT, cliente_id INTEGER, ativo INTEGER NOT NULL DEFAULT 0, mensagem TEXT, PRIMARY KEY (gatilho, cliente_id));`,
                 `CREATE TABLE IF NOT EXISTS integrations (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL, platform TEXT NOT NULL, name TEXT NOT NULL, unique_path TEXT NOT NULL UNIQUE, secret_key TEXT, status TEXT DEFAULT 'active', FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE);`,
+                `CREATE TABLE IF NOT EXISTS integration_settings (user_id INTEGER PRIMARY KEY, postback_secret TEXT, rastreio_api_key TEXT, webhook_url TEXT, FOREIGN KEY (user_id) REFERENCES users(id));`,
+                `CREATE TABLE IF NOT EXISTS user_settings (user_id INTEGER PRIMARY KEY, create_contact_on_message INTEGER DEFAULT 0, FOREIGN KEY (user_id) REFERENCES users(id));`,
             ];
 
             db.serialize(() => {


### PR DESCRIPTION
## Summary
- add missing `integration_settings` and `user_settings` tables
- log any errors during registration

## Testing
- `curl -X POST http://localhost:3000/api/register -H "Content-Type: application/json" -d '{"email":"test@example.com", "password":"123456"}' -i`

------
https://chatgpt.com/codex/tasks/task_e_686c662195c483219dca644f7525e934