### PR TITLE
Fix automation id for order cancelled message

### DIFF
--- a/src/constants/defaultMessages.js
+++ b/src/constants/defaultMessages.js
@@ -6,7 +6,7 @@ const DEFAULT_MESSAGES = {
     pedido_devolvido: "Atenção {{primeiro_nome}}, o seu pedido foi devolvido ao remetente. Por favor, entre em contato connosco para resolvermos a situação. Código: {{codigo_rastreio}}",
     // --- NOVAS MENSAGENS PADRÃO AQUI ---
     pedido_a_espera: 'Olá {{primeiro_nome}}! O seu pedido está a espera. Agradecemos o seu contato!',
-    boas_cancelado: 'Olá {{primeiro_nome}}! seu pedido foi cancelado. Agradecemos o seu contato!'
+    pedido_cancelado: 'Olá {{primeiro_nome}}! seu pedido foi cancelado. Agradecemos o seu contato!'
 };
 
 module.exports = DEFAULT_MESSAGES;

--- a/src/controllers/envioController.js
+++ b/src/controllers/envioController.js
@@ -63,7 +63,7 @@ async function enviarMensagensComRegras(db, broadcast, sessions) {
                     mensagemParaEnviar = personalizarMensagem(mensagemBase, pedido);
                 }
             }
-            else if (codigoRastreio && !['envio_rastreio', 'pedido_a_caminho', 'pedido_atrasado', 'pedido_devolvido', 'pedido_a_espera', 'boas_cancelado'].includes(mensagemUltimoStatus)) {
+            else if (codigoRastreio && !['envio_rastreio', 'pedido_a_caminho', 'pedido_atrasado', 'pedido_devolvido', 'pedido_a_espera', 'pedido_cancelado'].includes(mensagemUltimoStatus)) {
                 const config = automacoes.envio_rastreio;
                  if (config && config.ativo) {
                     novoStatusDaMensagem = 'envio_rastreio';


### PR DESCRIPTION
## Summary
- align automation key to `pedido_cancelado`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c74498078832189987da9d0492846