### PR TITLE
Ensure subscription creation on signup

### DIFF
--- a/src/services/planService.js
+++ b/src/services/planService.js
@@ -1,0 +1,11 @@
+function ensureFreePlan(db) {
+  return new Promise((resolve, reject) => {
+    const sql = "INSERT OR IGNORE INTO plans (id, name, price, monthly_limit, checkout_url) VALUES (1, 'Gr\u00e1tis', 0, 10, NULL)";
+    db.run(sql, [], function(err) {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+}
+
+module.exports = { ensureFreePlan };


### PR DESCRIPTION
## Summary
- fix `/api/register` to guarantee default free plan exists
- rollback user if subscription creation fails
- add simple planService with an `ensureFreePlan` helper

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d35548e788321972f898b0e499895