### PR TITLE
Implementa novo relatório de rastreamento

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
                 <li><button class="nav-btn" data-view="automations-view" title="Automações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 16.5 3.5 10l.9-8.6L13 1l8.6.9L18 10l-4 1 3 3-3 3-4-1zM2 22l4-4"></path><path d="m14.2 11.2 4.6-4.6"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="integrations-view" title="Integrações"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.72"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.72"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="reports-view" title="Relatórios"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"></path><path d="M18.7 8a6 6 0 0 0-6-6H3.3"></path><path d="M7 12h5"></path><path d="M7 16h9"></path></svg></button></li>
-                <li><button class="nav-btn" data-view="logs-view" title="Consumo"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"></path><path d="M8 6h8"></path><path d="M8 10h8"></path><path d="M8 14h8"></path></svg></button></li>
+                <li><button class="nav-btn" data-view="tracking-view" title="Rastreios"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"></path><path d="M16 3h5v5"></path><path d="M22 3 16 9"></path></svg></button></li>
                 <li><button class="nav-btn" data-view="plans-view" title="Planos"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"></rect><line x1="1" y1="10" x2="23" y2="10"></line></svg></button></li>
             </ul>
             <ul>
@@ -432,15 +432,28 @@
                 </div>
             </div>
 
-            <div id="logs-view" class="view-container hidden">
+            <div id="tracking-view" class="view-container hidden">
                 <div class="page-container">
                     <header class="page-header">
                         <div>
-                            <h1>Relatório de Consumo</h1>
-                            <p id="billing-summary">Pedidos contabilizados neste ciclo.</p>
+                            <h1>Clientes com Rastreamento</h1>
+                            <input type="text" id="tracking-search-input" placeholder="Buscar por nome, produto ou código" />
                         </div>
                     </header>
-                    <div id="billing-list-container">
+                    <div class="table-wrapper">
+                        <table id="tracking-table">
+                            <thead>
+                                <tr>
+                                    <th>Cliente</th>
+                                    <th>Contato</th>
+                                    <th>Produto</th>
+                                    <th>Código</th>
+                                    <th>Data de Envio</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tracking-table-body"></tbody>
+                        </table>
                     </div>
                 </div>
             </div>

--- a/public/style.css
+++ b/public/style.css
@@ -323,14 +323,12 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 #logs-table th, #logs-table td { padding: 12px 15px; text-align: left; border-bottom: 1px solid var(--border-color); }
 #logs-table thead th { background-color: var(--hover-bg); font-weight: 600; color: var(--text-secondary); }
 #logs-table tbody tr:last-child td { border-bottom: none; }
-.billing-empty {
-  text-align: center;
-}
-#billing-table { width: 100%; border-collapse: collapse; }
-#billing-table th, #billing-table td { padding: 12px 15px; text-align: left; border-bottom: 1px solid var(--border-color); }
-#billing-table thead th { background-color: var(--hover-bg); font-weight: 600; color: var(--text-secondary); }
-#billing-table tbody tr:nth-child(even) { background-color: var(--hover-bg); }
-#billing-table tbody tr:last-child td { border-bottom: none; }
+#tracking-table { width: 100%; border-collapse: collapse; }
+#tracking-table th, #tracking-table td { padding: 12px 15px; text-align: left; border-bottom: 1px solid var(--border-color); }
+#tracking-table thead th { background-color: var(--hover-bg); font-weight: 600; color: var(--text-secondary); }
+#tracking-table tbody tr:nth-child(even) { background-color: var(--hover-bg); }
+#tracking-table tbody tr:last-child td { border-bottom: none; }
+.btn-copy-code { background: none; border: none; cursor: pointer; margin-left: 4px; }
 .status-badge { padding: 4px 10px; border-radius: 12px; font-size: 0.8rem; font-weight: 600; }
 .status-badge.success { background-color: #dcfce7; color: #166534; }
 .status-badge.error { background-color: #fee2e2; color: #991b1b; }
@@ -1205,116 +1203,6 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     outline: none;
 }
 
-/* =================================
-   NOVOS ESTILOS PARA RELATÓRIO DE CONSUMO
-   ================================= */
-
-#billing-list-container {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-}
-
-.billing-item {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-    background-color: #ffffff;
-    padding: 16px 20px;
-    border: 1px solid var(--border-color);
-    border-radius: 12px;
-    transition: all 0.2s ease-out;
-}
-
-.billing-item:hover {
-    border-color: var(--primary-color);
-    box-shadow: 0 4px 10px -2px rgba(0,0,0,0.05);
-    transform: translateY(-2px);
-}
-
-.billing-status-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-.billing-info {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-}
-
-.billing-code {
-    font-weight: 600;
-    color: var(--text-color);
-    text-decoration: none;
-    font-size: 1rem;
-}
-.billing-code:hover {
-    text-decoration: underline;
-}
-
-.billing-customer {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-}
-
-.billing-status-tag {
-    padding: 5px 12px;
-    border-radius: 16px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    flex-shrink: 0;
-}
-
-/* Cores para cada Status */
-.status-dot.status-success, .tag-success { background-color: #dcfce7; color: #166534; }
-.billing-status-dot.status-success { background-color: #22c55e; }
-
-.status-dot.status-info, .tag-info { background-color: #e0f2fe; color: #0c4a6e; }
-.billing-status-dot.status-info { background-color: #3b82f6; }
-
-.status-dot.status-warning, .tag-warning { background-color: #fefce8; color: #854d0e; }
-.billing-status-dot.status-warning { background-color: #eab308; }
-
-.status-dot.status-danger, .tag-danger { background-color: #fee2e2; color: #991b1b; }
-.billing-status-dot.status-danger { background-color: #ef4444; }
-
-.status-dot.status-default, .tag-default { background-color: #f3f4f6; color: #4b5563; }
-.billing-status-dot.status-default { background-color: #9ca3af; }
-
-/* =================================
-   ESTILOS PARA OS DETALHES ADICIONAIS
-   ================================= */
-
-.billing-info {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.billing-info-main {
-    display: flex;
-    flex-direction: column;
-}
-
-.billing-info-meta {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-}
-
-.billing-info-meta strong {
-    color: var(--text-color);
-    font-weight: 500;
-}
-
-.meta-divider {
-    color: var(--border-color);
-}
 
 .report-card.danger-card {
     background-color: #fee2e2;

--- a/src/app.js
+++ b/src/app.js
@@ -145,7 +145,7 @@ function createExpressApp(db, sessionManager) {
   app.post('/api/automations', planCheck, automationsController.salvarAutomacoes);
 
   app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
-  app.get('/api/billing/history', planCheck, reportsController.getBillingHistory);
+  app.get('/api/reports/tracking', planCheck, reportsController.getTrackingReport);
 
   app.get('/api/logs', planCheck, logsController.listarLogs);
 


### PR DESCRIPTION
## Resumo
- remove o relatório antigo de consumo
- cria endpoint `/api/reports/tracking`
- adiciona nova tela de clientes com rastreio
- inclui busca dinâmica e cópia rápida do código

## Testes
- `npm test` *(falha: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6870136ed99483218814a4c0434e5766