### PR TITLE
Implement clientes-com-rastreio report

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -806,6 +806,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
             return response.json();
         })
         .then(data => {
+            trackingDataCache = Array.isArray(data) ? data : [];
             const tabelaCorpo = document.getElementById('corpo-tabela-relatorio');
 
             if (!tabelaCorpo) {

--- a/src/app.js
+++ b/src/app.js
@@ -146,6 +146,7 @@ function createExpressApp(db, sessionManager) {
 
   app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
   app.get('/api/reports/tracking', planCheck, reportsController.getTrackingReport);
+  app.get('/api/reports/clientes-com-rastreio', planCheck, reportsController.getClientesComRastreio);
 
   app.get('/api/logs', planCheck, logsController.listarLogs);
 

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -84,3 +84,25 @@ exports.getTrackingReport = async (req, res) => {
     }
 };
 
+exports.getClientesComRastreio = async (req, res) => {
+    try {
+        const db = req.db;
+        const clienteId = req.user.id;
+
+        const sql = `SELECT nome, produto, codigoRastreio,
+                            statusInterno AS status,
+                            dataCriacao AS createdAt
+                     FROM pedidos
+                     WHERE cliente_id = ?
+                       AND codigoRastreio IS NOT NULL
+                       AND codigoRastreio != ''
+                     ORDER BY dataCriacao DESC`;
+
+        const rows = await runQuery(db, sql, [clienteId]);
+        res.json(rows);
+    } catch (err) {
+        console.error('Erro ao obter clientes com rastreio:', err);
+        res.status(500).json({ error: 'Falha ao gerar relatório.' });
+    }
+};
+


### PR DESCRIPTION
## Summary
- implement `/api/reports/clientes-com-rastreio` endpoint
- expose new route in Express app
- keep tracking data cache on client side

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687026d89f408321907abdd89a8d7978