### PR TITLE
Refatora processamento de mensagens e cria teste

### DIFF
--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -328,4 +328,5 @@ module.exports = {
     marcarComoLido,
     criarPedido,
     getPedidosComCodigoAtivo,
+    normalizeTelefone,
 };

--- a/src/utils/messageUtils.js
+++ b/src/utils/messageUtils.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Process an incoming WhatsApp message, downloading media when necessary.
+ * @param {Object} client Venom client instance used to decrypt files
+ * @param {Object} message Message object from venom
+ * @returns {Promise<{messageContent:string, messageType:string, mediaUrl:string|null}>}
+ */
+async function processIncomingMessage(client, message) {
+  let messageContent = message.body;
+  let messageType = 'texto';
+  let mediaUrl = null;
+
+  const uploadDir = path.join(__dirname, '..', '..', 'public', 'uploads');
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+
+  const isMedia = message.isMedia || message.isMMS || ['image', 'video', 'audio', 'document', 'ptt'].includes(message.type);
+  if (isMedia) {
+    try {
+      const buffer = await client.decryptFile(message);
+      const ext = message.type === 'ptt' ? 'ogg' : (message.mimetype ? message.mimetype.split('/')[1] : 'bin');
+      const prefix = message.type === 'ptt' ? 'audio' : 'media';
+      const fileName = `${prefix}_${Date.now()}.${ext}`;
+      const filePath = path.join(uploadDir, fileName);
+      fs.writeFileSync(filePath, buffer);
+      mediaUrl = `/uploads/${fileName}`;
+      messageContent = message.caption || (message.type === 'ptt' ? '[ÁUDIO]' : '');
+      messageType = message.type === 'ptt' ? 'audio' : message.type;
+    } catch (err) {
+      console.error('Erro ao baixar mídia:', err);
+      messageContent = `[MÍDIA NÃO BAIXADA] ${message.body}`;
+      messageType = 'texto';
+      mediaUrl = null;
+    }
+  }
+
+  return { messageContent, messageType, mediaUrl };
+}
+
+module.exports = { processIncomingMessage };

--- a/tests/normalizeTelefone.test.js
+++ b/tests/normalizeTelefone.test.js
@@ -1,0 +1,14 @@
+const { normalizeTelefone } = require('../src/services/pedidoService');
+
+describe('normalizeTelefone', () => {
+  test('normalizes various formats', () => {
+    expect(normalizeTelefone('11 98765-4321')).toBe('5511987654321');
+    expect(normalizeTelefone('(11)98765-4321')).toBe('5511987654321');
+    expect(normalizeTelefone('11987654321')).toBe('5511987654321');
+    expect(normalizeTelefone('5511987654321')).toBe('5511987654321');
+  });
+
+  test('returns null for invalid numbers', () => {
+    expect(normalizeTelefone('12345')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to process incoming WhatsApp messages
- use the helper in `whatsappSessions` for cleaner logic
- export `normalizeTelefone` and add unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717975b8948321a111ab20fe2712d0