### PR TITLE
Enable media messages in automations

### DIFF
--- a/migrations/20250712100000-add-media-fields-to-automacoes.js
+++ b/migrations/20250712100000-add-media-fields-to-automacoes.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('automacoes', 'tipo_midia', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'texto'
+    });
+    await queryInterface.addColumn('automacoes', 'url_midia', {
+      type: Sequelize.STRING,
+      allowNull: true
+    });
+    await queryInterface.addColumn('automacoes', 'legenda_midia', {
+      type: Sequelize.STRING,
+      allowNull: true
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('automacoes', 'tipo_midia');
+    await queryInterface.removeColumn('automacoes', 'url_midia');
+    await queryInterface.removeColumn('automacoes', 'legenda_midia');
+  }
+};

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -129,7 +129,10 @@ function defineModels(sequelize) {
     gatilho: { type: DataTypes.STRING, primaryKey: true },
     cliente_id: { type: DataTypes.INTEGER, primaryKey: true },
     ativo: { type: DataTypes.INTEGER, defaultValue: 0 },
-    mensagem: DataTypes.STRING
+    mensagem: DataTypes.STRING,
+    tipo_midia: { type: DataTypes.STRING, defaultValue: 'texto' },
+    url_midia: DataTypes.STRING,
+    legenda_midia: DataTypes.STRING
   }, { tableName: 'automacoes', timestamps: false });
 
   const Integration = sequelize.define('Integration', {

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -103,6 +103,20 @@ async function sendAudio(client, telefone, audioUrl) {
     await client.sendVoice(numeroFormatado, audioUrl);
 }
 
+async function sendFile(client, telefone, fileUrl, fileName, caption = '') {
+    if (!client) throw new Error('Cliente WhatsApp não iniciado.');
+    const numeroNormalizado = normalizeTelefone(telefone);
+    const numeroFormatado = `${numeroNormalizado}@c.us`;
+    await client.sendFile(numeroFormatado, fileUrl, fileName, caption);
+}
+
+async function sendVideo(client, telefone, videoUrl, caption = '') {
+    if (!client) throw new Error('Cliente WhatsApp não iniciado.');
+    const numeroNormalizado = normalizeTelefone(telefone);
+    const numeroFormatado = `${numeroNormalizado}@c.us`;
+    await client.sendVideo(numeroFormatado, videoUrl, caption);
+}
+
 /**
  * Busca a URL da foto de perfil, primeiro pela API e depois com fallback via Puppeteer.
  * @param {string} telefone O número do contato.
@@ -142,5 +156,7 @@ module.exports = {
     enviarMensagem,
     sendImage,
     sendAudio,
+    sendFile,
+    sendVideo,
     getProfilePicUrl
 };


### PR DESCRIPTION
## Summary
- add DB migration for media fields in automations
- update Automacao model to include media columns
- allow saving/loading media data in automation service
- support sending images, audios, documents and videos in envioController
- add helper functions sendFile and sendVideo in WhatsApp service

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68723bfc5c248321a774c72012f0f00e