### PR TITLE
Implement step-based automations

### DIFF
--- a/migrations/20250713100000-create-automacao-passos.js
+++ b/migrations/20250713100000-create-automacao-passos.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('automacao_passos', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      gatilho: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      cliente_id: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      ordem: {
+        type: Sequelize.INTEGER,
+        allowNull: false
+      },
+      tipo: {
+        type: Sequelize.STRING,
+        allowNull: false
+      },
+      conteudo: {
+        type: Sequelize.TEXT,
+        allowNull: true
+      },
+      mediaUrl: {
+        type: Sequelize.STRING,
+        allowNull: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.fn('NOW')
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('automacao_passos');
+  }
+};

--- a/public/script.js
+++ b/public/script.js
@@ -662,6 +662,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
                     const selectTipo = card.querySelector('.select-tipo-midia');
                     const inputUrl = card.querySelector('.input-url-midia');
                     const inputLegenda = card.querySelector('.input-legenda-midia');
+                    const step = config.steps && config.steps[0];
                     if (toggle) toggle.checked = config.ativo;
                     if (textarea) {
                         textarea.value = config.mensagem;
@@ -669,15 +670,15 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
                         highlightVariables(textarea);
                     }
                     if (selectTipo) {
-                        selectTipo.value = config.tipo_midia || 'texto';
+                        selectTipo.value = step ? step.tipo : 'texto';
                         selectTipo.disabled = !config.ativo;
                     }
                     if (inputUrl) {
-                        inputUrl.value = config.url_midia || '';
+                        inputUrl.value = step && step.mediaUrl ? step.mediaUrl : '';
                         inputUrl.disabled = !config.ativo;
                     }
                     if (inputLegenda) {
-                        inputLegenda.value = config.legenda_midia || '';
+                        inputLegenda.value = step ? step.conteudo : '';
                         inputLegenda.disabled = !config.ativo;
                     }
                     if (toggleLabel) toggleLabel.textContent = config.ativo ? 'Ativado' : 'Desativado';
@@ -701,12 +702,17 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
             const selectTipo = card.querySelector('.select-tipo-midia');
             const inputUrl = card.querySelector('.input-url-midia');
             const inputLegenda = card.querySelector('.input-legenda-midia');
+            const tipo = selectTipo ? selectTipo.value : 'texto';
+            const step = {
+                ordem: 1,
+                tipo,
+                conteudo: tipo === 'texto' ? messageTextarea.value : (inputLegenda ? inputLegenda.value : ''),
+                mediaUrl: tipo === 'texto' ? null : (inputUrl ? inputUrl.value.trim() : '')
+            };
             novasConfiguracoes[automationId] = {
                 ativo: toggle.checked,
                 mensagem: messageTextarea.value,
-                tipo_midia: selectTipo ? selectTipo.value : 'texto',
-                url_midia: inputUrl ? inputUrl.value.trim() : '',
-                legenda_midia: inputLegenda ? inputLegenda.value : ''
+                steps: [step]
             };
         });
         try {

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -135,6 +135,16 @@ function defineModels(sequelize) {
     legenda_midia: DataTypes.STRING
   }, { tableName: 'automacoes', timestamps: false });
 
+  const AutomacaoPasso = sequelize.define('AutomacaoPasso', {
+    id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+    gatilho: { type: DataTypes.STRING, allowNull: false },
+    cliente_id: { type: DataTypes.INTEGER, allowNull: false },
+    ordem: { type: DataTypes.INTEGER, allowNull: false },
+    tipo: { type: DataTypes.STRING, allowNull: false },
+    conteudo: DataTypes.TEXT,
+    mediaUrl: DataTypes.STRING
+  }, { tableName: 'automacao_passos', timestamps: true });
+
   const Integration = sequelize.define('Integration', {
     id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
     user_id: { type: DataTypes.INTEGER, allowNull: false },
@@ -166,7 +176,10 @@ function defineModels(sequelize) {
   Pedido.hasMany(Historico, { foreignKey: 'pedido_id' });
   Historico.belongsTo(Pedido, { foreignKey: 'pedido_id' });
 
-  return { User, Plan, Subscription, Pedido, Historico, Log, Automacao, Integration, IntegrationSetting, UserSetting };
+  Automacao.hasMany(AutomacaoPasso, { foreignKey: 'gatilho', sourceKey: 'gatilho' });
+  AutomacaoPasso.belongsTo(Automacao, { foreignKey: 'gatilho', targetKey: 'gatilho' });
+
+  return { User, Plan, Subscription, Pedido, Historico, Log, Automacao, AutomacaoPasso, Integration, IntegrationSetting, UserSetting };
 }
 
 let sequelize;


### PR DESCRIPTION
## Summary
- create `automacao_passos` table for ordered automation messages
- load and store automation steps in automation service
- execute automation steps when sending messages
- update WhatsApp message sending controller to handle steps
- adjust frontend to send automation steps

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687324b8dd4c8321aca7ae34e4620e10