### PR TITLE
Fix createDefaultAutomations async error

### DIFF
--- a/src/services/automationService.js
+++ b/src/services/automationService.js
@@ -100,7 +100,7 @@ exports.saveAutomations = (db, configs, clienteId = null) => {
 const { getModels } = require('../database/database');
 
 // Cria registros padrão de automações para um novo usuário
-exports.createDefaultAutomations = (db, clienteId, options = {}) => {
+exports.createDefaultAutomations = async (db, clienteId, options = {}) => {
     if (options.transaction) {
         const { Automacao, AutomacaoPasso } = getModels();
         const records = Object.entries(DEFAULT_MESSAGES).map(([gatilho, mensagem]) => ({


### PR DESCRIPTION
## Summary
- mark `createDefaultAutomations` as async so `await` is valid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68732bf58cb08321abf58f614931609f