### PR TITLE
Implement dynamic automation step builder

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -178,17 +178,12 @@
                     <div class="automation-header"><h3>Mensagem de Boas-Vindas</h3><p>Enviada quando um novo contato é adicionado.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -196,17 +191,12 @@
                     <div class="automation-header"><h3>Envio do Código de Rastreio</h3><p>Enviada quando um código de rastreio é adicionado.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -214,17 +204,12 @@
                     <div class="automation-header"><h3>Pedido a Caminho</h3><p>Enviada quando o status do pedido muda para "A caminho".</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -232,17 +217,12 @@
                     <div class="automation-header"><h3>Alerta de Pedido em Atraso</h3><p>Enviada quando o sistema detecta um possível atraso na entrega.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -250,17 +230,12 @@
                     <div class="automation-header"><h3>Alerta de Pedido em Espera</h3><p>Enviada quando o pedido fica em espera ou aguardando retirada.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -268,17 +243,12 @@
                     <div class="automation-header"><h3>Alerta de Pedido Devolvido</h3><p>Enviada quando o rastreio indica que o objeto foi devolvido.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>
@@ -286,17 +256,12 @@
                     <div class="automation-header"><h3>Notificação de Pedido Cancelado</h3><p>Enviada quando um pedido é cancelado.</p></div>
                     <div class="automation-body">
                         <div class="toggle-container"><label class="switch"><input type="checkbox" class="automation-toggle"><span class="slider round"></span></label><span class="toggle-label">Desativado/Ativado</span></div>
-                        <div class="editor-wrapper"><textarea class="automation-message" placeholder="Escreva a sua mensagem aqui..."></textarea></div>
-                        <div class="media-config">
-                            <select class="select-tipo-midia">
-                                <option value="texto">Apenas texto</option>
-                                <option value="imagem">Imagem</option>
-                                <option value="audio">Áudio</option>
-                                <option value="documento">Arquivo</option>
-                                <option value="video">Vídeo</option>
-                            </select>
-                            <input type="text" class="input-url-midia" placeholder="URL da mídia">
-                            <input type="text" class="input-legenda-midia" placeholder="Legenda (opcional)">
+                        <div class="steps-container"></div>
+                        <div class="add-step-buttons">
+                            <span>Adicionar passo:</span>
+                            <button type="button" class="btn-primary" onclick="addStep(this.closest('.automation-card'),'texto')">Texto</button>
+                            <button type="button" class="btn-info" onclick="addStep(this.closest('.automation-card'),'imagem')">Mídia</button>
+                            <button type="button" class="btn-secondary" onclick="addStep(this.closest('.automation-card'),'arquivo')">Arquivo</button>
                         </div>
                     </div>
                 </div>

--- a/public/style.css
+++ b/public/style.css
@@ -1762,3 +1762,6 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .step-controls button { margin-left: 5px; }
 .step-content { display: none; }
 .file-name-display { color: #555; font-style: italic; margin-top: 5px; }
+.steps-container { margin-top: 10px; }
+.add-step-buttons { margin-top: 10px; display: flex; gap: 8px; align-items: center; }
+.add-step-buttons span { font-weight: 500; }


### PR DESCRIPTION
## Summary
- convert automation cards to use a multi-step builder
- implement step builder logic in the main script
- adjust automation save/load routines for steps
- add minor styling for step builder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740ecd39808321bc4cb0c80f55cda2