### PR TITLE
Fix automation builder visibility and style

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -180,75 +180,81 @@ document.addEventListener('DOMContentLoaded', () => {
         chatMessages.scrollTop = chatMessages.scrollHeight;
     };
 
-    // ----- Automation Builder Functions -----
-    let stepCounter = 0;
-
-    window.addStep = function(type) {
-        stepCounter++;
-        const container = document.getElementById('steps-container');
-        const stepCard = document.createElement('div');
-        stepCard.className = 'automation-step';
-        stepCard.id = `step-${stepCounter}`;
-        stepCard.dataset.type = type;
-        stepCard.innerHTML = `
-            <div class="step-header">
-                <h5>Passo <span class="step-order-number"></span>: ${capitalize(type)}</h5>
-                <div class="step-controls">
-                    <button type="button" class="btn btn-light btn-sm" onclick="moveStep(this, 'up')">▲</button>
-                    <button type="button" class="btn btn-light btn-sm" onclick="moveStep(this, 'down')">▼</button>
-                    <button type="button" class="btn btn-danger btn-sm" onclick="removeStep(this)">×</button>
-                </div>
-            </div>
-            <div class="form-group">
-                <label>${type === 'texto' ? 'Mensagem de Texto' : 'Legenda (opcional)'}</label>
-                <textarea class="form-control step-text-content" rows="3"></textarea>
-            </div>
-            <div class="form-group step-file-content" style="display: ${type === 'texto' ? 'none' : 'block'};">
-                <label>Selecione o arquivo</label>
-                <input type="file" class="form-control-file step-file-input" onchange="displayFileName(this)">
-                <div class="file-name-display"></div>
-            </div>
-        `;
-        container.appendChild(stepCard);
-        updateStepNumbers();
-    };
-
-    window.removeStep = function(buttonElement) {
-        buttonElement.closest('.automation-step').remove();
-        updateStepNumbers();
-    };
-
-    window.moveStep = function(buttonElement, direction) {
-        const stepCard = buttonElement.closest('.automation-step');
-        const container = stepCard.parentNode;
-        if (direction === 'up') {
-            const previousSibling = stepCard.previousElementSibling;
-            if (previousSibling) container.insertBefore(stepCard, previousSibling);
-        } else {
-            const nextSibling = stepCard.nextElementSibling;
-            if (nextSibling) container.insertBefore(nextSibling, stepCard);
-        }
-        updateStepNumbers();
-    };
-
-    window.displayFileName = function(inputElement) {
-        const fileNameDisplay = inputElement.nextElementSibling;
-        if (inputElement.files.length > 0) {
-            fileNameDisplay.textContent = `Arquivo selecionado: ${inputElement.files[0].name}`;
-        } else {
-            fileNameDisplay.textContent = '';
-        }
-    };
-
-    function updateStepNumbers() {
-        const allSteps = document.querySelectorAll('#steps-container .automation-step');
-        allSteps.forEach((step, index) => {
-            step.querySelector('.step-order-number').textContent = index + 1;
-            step.dataset.order = index + 1;
-        });
-    }
-
-    function capitalize(s) {
-        return s.charAt(0).toUpperCase() + s.slice(1);
-    }
 });
+
+// ----- Automation Builder Functions (global) -----
+let stepCounter = 0;
+
+function addStep(type) {
+    stepCounter++;
+    const container = document.getElementById('steps-container');
+    const stepCard = document.createElement('div');
+    stepCard.className = 'automation-step';
+    stepCard.id = `step-${stepCounter}`;
+    stepCard.dataset.type = type;
+    stepCard.innerHTML = `
+        <div class="step-header">
+            <h5>Passo <span class="step-order-number"></span>: ${capitalize(type)}</h5>
+            <div class="step-controls">
+                <button type="button" class="btn btn-light btn-sm" onclick="moveStep(this, 'up')">▲</button>
+                <button type="button" class="btn btn-light btn-sm" onclick="moveStep(this, 'down')">▼</button>
+                <button type="button" class="btn btn-danger btn-sm" onclick="removeStep(this)">×</button>
+            </div>
+        </div>
+        <div class="form-group">
+            <label>${type === 'texto' ? 'Mensagem de Texto' : 'Legenda (opcional)'}</label>
+            <textarea class="form-control step-text-content" rows="3"></textarea>
+        </div>
+        <div class="form-group step-file-content" style="display: ${type === 'texto' ? 'none' : 'block'};">
+            <label>Selecione o arquivo</label>
+            <input type="file" class="form-control-file step-file-input" onchange="displayFileName(this)">
+            <div class="file-name-display"></div>
+        </div>
+    `;
+    container.appendChild(stepCard);
+    updateStepNumbers();
+}
+
+function removeStep(buttonElement) {
+    buttonElement.closest('.automation-step').remove();
+    updateStepNumbers();
+}
+
+function moveStep(buttonElement, direction) {
+    const stepCard = buttonElement.closest('.automation-step');
+    const container = stepCard.parentNode;
+    if (direction === 'up') {
+        const previousSibling = stepCard.previousElementSibling;
+        if (previousSibling) container.insertBefore(stepCard, previousSibling);
+    } else {
+        const nextSibling = stepCard.nextElementSibling;
+        if (nextSibling) container.insertBefore(nextSibling, stepCard);
+    }
+    updateStepNumbers();
+}
+
+function displayFileName(inputElement) {
+    const fileNameDisplay = inputElement.nextElementSibling;
+    if (inputElement.files.length > 0) {
+        fileNameDisplay.textContent = `Arquivo selecionado: ${inputElement.files[0].name}`;
+    } else {
+        fileNameDisplay.textContent = '';
+    }
+}
+
+function updateStepNumbers() {
+    const allSteps = document.querySelectorAll('#steps-container .automation-step');
+    allSteps.forEach((step, index) => {
+        const orderSpan = step.querySelector('.step-order-number');
+        if (orderSpan) {
+            orderSpan.textContent = index + 1;
+        }
+        step.dataset.order = index + 1;
+    });
+}
+
+function capitalize(s) {
+    if (!s) return '';
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+

--- a/public/style.css
+++ b/public/style.css
@@ -1755,13 +1755,61 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 }
 
 /* Styles for automation builder */
-#automation-builder { border: 1px solid #ddd; padding: 15px; border-radius: 5px; background-color: #f9f9f9; }
-.automation-step { border: 1px solid #ccc; background-color: white; border-radius: 5px; padding: 15px; margin-bottom: 10px; }
-.step-header { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 10px; }
-.step-header h5 { margin: 0; }
-.step-controls button { margin-left: 5px; }
-.step-content { display: none; }
-.file-name-display { color: #555; font-style: italic; margin-top: 5px; }
-.steps-container { margin-top: 10px; }
-.add-step-buttons { margin-top: 10px; display: flex; gap: 8px; align-items: center; }
-.add-step-buttons span { font-weight: 500; }
+#automation-builder {
+    border: 1px solid #e0e0e0;
+    padding: 20px;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    margin-top: 20px;
+}
+
+#add-step-buttons {
+    margin-top: 15px;
+    padding-top: 15px;
+    border-top: 1px dashed #ccc;
+}
+
+#add-step-buttons span {
+    margin-right: 10px;
+    font-weight: 500;
+}
+
+#add-step-buttons .btn {
+    margin-right: 5px;
+}
+
+.automation-step {
+    border: 1px solid #ccc;
+    background-color: white;
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 15px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+.automation-step .step-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+}
+
+.automation-step .step-header h5 {
+    margin: 0;
+    font-size: 1em;
+    font-weight: 600;
+    color: #333;
+}
+
+.file-name-display {
+    color: #007bff;
+    font-style: italic;
+    margin-top: 8px;
+    font-size: 0.9em;
+    padding: 6px;
+    background-color: #e9f5ff;
+    border-radius: 4px;
+    display: inline-block;
+}


### PR DESCRIPTION
## Summary
- refine CSS for automation builder cards, buttons and file label
- expose automation builder functions globally in `admin.js`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: Failed to download chrome-headless-shell)*

------
https://chatgpt.com/codex/tasks/task_e_687416754f2483219cec5c50d0ca3e78