### PR TITLE
Add admin client deletion

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -81,19 +81,23 @@ document.addEventListener('DOMContentLoaded', () => {
                 data.clients.forEach(c => {
                     const tr = document.createElement('tr');
                     tr.innerHTML = `<td>${c.email}</td><td>${c.is_active ? 'Sim' : 'Não'}</td><td>${c.requests}</td>`;
-                    const actionsTd = document.createElement('td');
-                    const toggleBtn = document.createElement('button');
-                    toggleBtn.textContent = c.is_active ? 'Desativar' : 'Ativar';
-                    toggleBtn.addEventListener('click', () => toggleActive(c.id, !c.is_active));
-                    const editBtn = document.createElement('button');
-                    editBtn.textContent = 'Editar';
-                    editBtn.addEventListener('click', () => openModal(c));
-                    actionsTd.appendChild(toggleBtn);
-                    actionsTd.appendChild(editBtn);
-                    tr.appendChild(actionsTd);
-                    tbody.appendChild(tr);
-                });
+                const actionsTd = document.createElement('td');
+                const toggleBtn = document.createElement('button');
+                toggleBtn.textContent = c.is_active ? 'Desativar' : 'Ativar';
+                toggleBtn.addEventListener('click', () => toggleActive(c.id, !c.is_active));
+                const editBtn = document.createElement('button');
+                editBtn.textContent = 'Editar';
+                editBtn.addEventListener('click', () => openModal(c));
+                const deleteBtn = document.createElement('button');
+                deleteBtn.textContent = 'Excluir';
+                deleteBtn.addEventListener('click', () => deleteClient(c.id));
+                actionsTd.appendChild(toggleBtn);
+                actionsTd.appendChild(editBtn);
+                actionsTd.appendChild(deleteBtn);
+                tr.appendChild(actionsTd);
+                tbody.appendChild(tr);
             });
+        });
     }
 
     function toggleActive(id, active) {
@@ -108,6 +112,12 @@ document.addEventListener('DOMContentLoaded', () => {
         document.getElementById('client-password').value = '';
         if (client && client.plan_id) plansSelect.value = client.plan_id;
         document.getElementById('client-modal').classList.add('active');
+    }
+
+    function deleteClient(id) {
+        if (!confirm('Deseja realmente excluir este cliente?')) return;
+        authFetch(`/api/admin/clients/${id}`, { method: 'DELETE' })
+            .then(() => loadClients());
     }
 
     document.getElementById('btn-new-client').addEventListener('click', () => openModal(null));

--- a/src/app.js
+++ b/src/app.js
@@ -100,6 +100,7 @@ function createExpressApp(db, sessionManager) {
   app.post('/api/admin/clients', adminCheck, adminController.createClient);
   app.put('/api/admin/clients/:id', adminCheck, adminController.updateClient);
   app.put('/api/admin/clients/:id/active', adminCheck, adminController.toggleActive);
+  app.delete('/api/admin/clients/:id', adminCheck, adminController.deleteClient);
   app.get('/api/admin/stats', adminCheck, adminController.getStats);
 
   app.get('/api/subscription', async (req, res) => {

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -63,6 +63,17 @@ exports.toggleActive = async (req, res) => {
     }
 };
 
+exports.deleteClient = async (req, res) => {
+    const id = parseInt(req.params.id);
+    try {
+        await userService.deleteUserCascade(req.db, id);
+        res.json({ message: 'Cliente excluído com sucesso' });
+    } catch (err) {
+        console.error('Erro ao excluir cliente:', err);
+        res.status(500).json({ error: 'Falha ao excluir cliente' });
+    }
+};
+
 // Estatísticas agregadas para o painel de admin
 exports.getStats = async (req, res) => {
     const db = req.db;


### PR DESCRIPTION
## Summary
- allow admins to remove clients
- expose DELETE /api/admin/clients/:id
- show Delete button in admin UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68741a4c5c00832190cc7ae04aed660e