### PR TITLE
Improve automation builder styling

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1759,7 +1759,7 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     border: 1px solid #e0e0e0;
     padding: 20px;
     border-radius: 8px;
-    background-color: #f9f9f9;
+    background-color: #f7f7f7;
     margin-top: 20px;
 }
 
@@ -1772,19 +1772,24 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 #add-step-buttons span {
     margin-right: 10px;
     font-weight: 500;
+    color: #555;
 }
 
 #add-step-buttons .btn {
-    margin-right: 5px;
+    margin-right: 8px;
 }
 
 .automation-step {
-    border: 1px solid #ccc;
-    background-color: white;
+    border: 1px solid #d1d1d1;
+    background-color: #fff;
     border-radius: 8px;
     padding: 15px;
     margin-bottom: 15px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.06);
+    transition: box-shadow 0.3s ease;
+}
+.automation-step:hover {
+    box-shadow: 0 4px 8px rgba(0,0,0,0.08);
 }
 
 .automation-step .step-header {
@@ -1798,18 +1803,17 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 
 .automation-step .step-header h5 {
     margin: 0;
-    font-size: 1em;
+    font-size: 1.1em;
     font-weight: 600;
-    color: #333;
 }
 
 .file-name-display {
-    color: #007bff;
+    color: #17a2b8;
     font-style: italic;
     margin-top: 8px;
-    font-size: 0.9em;
-    padding: 6px;
-    background-color: #e9f5ff;
+    padding: 8px;
+    background-color: #e8f7fa;
     border-radius: 4px;
     display: inline-block;
+    font-size: 0.9em;
 }


### PR DESCRIPTION
## Summary
- tweak automation builder CSS for more polished appearance

## Testing
- `npm test` *(fails: jest not found after `npm install` fails due to blocked Puppeteer download)*

------
https://chatgpt.com/codex/tasks/task_e_687420fa0fcc83218f070ff2c8ed50a2