### PR TITLE
UI polish for automation builder

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1904,3 +1904,9 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
     }
     showView('chat-view');
 });
+
+// Expor funções do construtor globalmente para inline handlers
+window.addStep = addStep;
+window.removeStep = removeStep;
+window.moveStep = moveStep;
+window.updateStepType = updateStepType;

--- a/public/style.css
+++ b/public/style.css
@@ -1763,7 +1763,8 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     margin-top: 20px;
 }
 
-#add-step-buttons {
+#add-step-buttons,
+.add-step-buttons {
     margin-top: 20px;
     padding-top: 20px;
     border-top: 1px dashed #ced4da;
@@ -1772,9 +1773,20 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     gap: 10px;
 }
 
-#add-step-buttons span {
+#add-step-buttons span,
+.add-step-buttons span {
     font-weight: 500;
     color: #495057;
+}
+
+.add-step-buttons button {
+    margin-left: 5px;
+}
+
+.steps-container {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
 }
 
 .automation-step {


### PR DESCRIPTION
## Summary
- tweak automation builder style
- expose builder functions globally so inline onclicks work

## Testing
- `npm test` *(fails: puppeteer install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68755f9201a08321b3fa4aa39636ffad