### PR TITLE
Fix Puppeteer profile pic scraping

### DIFF
--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -33,7 +33,7 @@ function normalizeTelefone(telefoneRaw) {
  */
 async function scrapeProfilePicViaPuppeteer(client, telefone) {
   const tel = normalizeTelefone(telefone);
-  const page = await client.pupBrowser.newPage();
+  const page = await client.browser.newPage();
   try {
     // Abre o chat do contato (já autenticado)
     await page.goto(`https://web.whatsapp.com/send?phone=${tel}`, { waitUntil: 'networkidle2' });


### PR DESCRIPTION
## Summary
- fix whatsapp service to use `client.browser` when scraping

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68758531d23c83219fcfad6948add91d