### PR TITLE
Improve profile pic lookup resilience

### DIFF
--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -140,31 +140,33 @@ async function sendVideo(client, telefone, videoUrl, caption = '') {
  */
 async function getProfilePicUrl(client, telefone) {
     if (!client) {
-        logger.warn("Cliente Venom não está pronto para buscar fotos.");
+        logger.debug("Cliente Venom não está pronto para buscar fotos.");
         return null;
     }
     const contatoId = `${normalizeTelefone(telefone)}@c.us`;
 
+    let viaApi = null;
     // --- ESTRATÉGIA 1: TENTATIVA VIA API OFICIAL DO VENOM ---
     try {
-        const viaApi = await client.getProfilePicFromServer(contatoId);
-        if (viaApi) {
-            return viaApi;
-        }
+        viaApi = await client.getProfilePicFromServer(contatoId);
     } catch (error) {
-        logger.warn(`[API] Falhou para ${contatoId}. Motivo: ${error.message}. Ativando fallback.`);
+        logger.debug(`[API] Falhou para ${contatoId}. Motivo: ${error.message}.`);
+    }
+    if (viaApi) {
+        return viaApi;
     }
 
     // --- ESTRATÉGIA 2: FALLBACK VIA SCRAPING ROBUSTO COM PUPPETEER ---
     try {
         const viaScrape = await scrapeProfilePicViaPuppeteer(client, telefone);
         if (viaScrape) {
+            return viaScrape;
         }
-        return viaScrape;
     } catch (err) {
-        logger.warn('Fallback Puppeteer falhou:', err);
-        return null;
+        logger.debug('Fallback Puppeteer falhou:', err);
     }
+
+    return null;
 }
 
 module.exports = {

--- a/tests/pedidoFlow.test.js
+++ b/tests/pedidoFlow.test.js
@@ -1,0 +1,36 @@
+const pedidoService = require('../src/services/pedidoService');
+const whatsappService = require('../src/services/whatsappService');
+const pedidosController = require('../src/controllers/pedidosController');
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('pedido creation and update with profile picture failure', () => {
+  test('criarPedido resolves when getProfilePicUrl fails', async () => {
+    jest.spyOn(whatsappService, 'getProfilePicUrl').mockRejectedValue(new Error('fail'));
+
+    const db = {
+      run: jest.fn((sql, params, cb) => cb.call({ lastID: 1 }, null))
+    };
+
+    const result = await pedidoService.criarPedido(db, { nome: 'Teste', telefone: '11987654321' }, {}, 1);
+    expect(result.fotoPerfilUrl).toBeNull();
+    expect(db.run).toHaveBeenCalled();
+  });
+
+  test('atualizarFotoDoPedido responde 200 quando foto falha', async () => {
+    jest.spyOn(whatsappService, 'getProfilePicUrl').mockResolvedValue(null);
+    jest.spyOn(pedidoService, 'getPedidoById').mockResolvedValue({ id: 2, telefone: '11987654321' });
+    const updateSpy = jest.spyOn(pedidoService, 'updateCamposPedido').mockResolvedValue({ changes: 1 });
+
+    const req = { db: {}, user: { id: 1 }, params: { id: 2 }, venomClient: {}, broadcast: jest.fn() };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+    await pedidosController.atualizarFotoDoPedido(req, res);
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ message: 'Nenhuma foto de perfil foi encontrada para este contato.', data: { fotoUrl: null } });
+  });
+});


### PR DESCRIPTION
## Summary
- log WhatsApp profile picture lookup errors with `debug`
- ensure `getProfilePicUrl` always returns null on failure
- add tests covering order creation and update when profile pic retrieval fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68766799ec1883219cd911f759b997cc