### PR TITLE
Replace profile pics with default avatar

### DIFF
--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -319,11 +319,7 @@ exports.atualizarFotoDoPedido = async (req, res) => {
     const db = req.db;
     const clienteId = req.user.id;
     const { id } = req.params;
-    const client = req.venomClient;
-
-    if (!client) {
-        return res.status(500).json({ error: "Cliente WhatsApp não está conectado." });
-    }
+    const client = req.venomClient; // mantido para compatibilidade, mas não é mais necessário
 
     try {
         const pedido = await pedidoService.getPedidoById(db, id, clienteId);
@@ -331,15 +327,11 @@ exports.atualizarFotoDoPedido = async (req, res) => {
             return res.status(404).json({ error: "Pedido não encontrado." });
         }
 
-        const fotoUrl = await whatsappService.getProfilePicUrl(client, pedido.telefone);
-        
-        if (fotoUrl) {
-            await pedidoService.updateCamposPedido(db, id, { fotoPerfilUrl: fotoUrl }, clienteId);
-            req.broadcast(clienteId, { type: 'pedido_atualizado', pedidoId: id });
-            res.status(200).json({ message: "Foto de perfil atualizada com sucesso!", data: { fotoUrl } });
-        } else {
-             res.status(200).json({ message: "Nenhuma foto de perfil foi encontrada para este contato.", data: { fotoUrl: null } });
-        }
+        const fotoUrl = await whatsappService.getProfilePicUrl();
+
+        await pedidoService.updateCamposPedido(db, id, { fotoPerfilUrl: fotoUrl }, clienteId);
+        req.broadcast(clienteId, { type: 'pedido_atualizado', pedidoId: id });
+        res.status(200).json({ message: "Foto de perfil atualizada com sucesso!", data: { fotoUrl } });
 
     } catch (error) {
         console.error("Erro ao tentar atualizar a foto do pedido:", error);

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -294,15 +294,7 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
             return reject(new Error("Nome e um número de celular válido são obrigatórios."));
         }
 
-        let fotoUrl = null;
-        if (client) {
-            try {
-                fotoUrl = await whatsappService.getProfilePicUrl(client, telefoneValidado);
-            } catch (e) {
-                logger.warn(`Não foi possível obter a foto para o novo contato ${telefoneValidado}.`);
-                fotoUrl = null;
-            }
-        }
+        const fotoUrl = await whatsappService.getProfilePicUrl();
 
         const sql = 'INSERT INTO pedidos (cliente_id, nome, email, telefone, produto, codigoRastreio, notas, fotoPerfilUrl, dataCriacao) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
         const params = [clienteId, nome, email || null, telefoneValidado, produto || null, codigoRastreio || null, notas || null, fotoUrl, new Date().toISOString()];

--- a/tests/pedidoFlow.test.js
+++ b/tests/pedidoFlow.test.js
@@ -6,21 +6,18 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-describe('pedido creation and update with profile picture failure', () => {
-  test('criarPedido resolves when getProfilePicUrl fails', async () => {
-    jest.spyOn(whatsappService, 'getProfilePicUrl').mockRejectedValue(new Error('fail'));
-
+describe('uso do avatar padrão', () => {
+  test('criarPedido define avatar padrão', async () => {
     const db = {
       run: jest.fn((sql, params, cb) => cb.call({ lastID: 1 }, null))
     };
 
     const result = await pedidoService.criarPedido(db, { nome: 'Teste', telefone: '11987654321' }, {}, 1);
-    expect(result.fotoPerfilUrl).toBeNull();
+    expect(result.fotoPerfilUrl).toBe(whatsappService.DEFAULT_AVATAR_URL);
     expect(db.run).toHaveBeenCalled();
   });
 
-  test('atualizarFotoDoPedido responde 200 quando foto falha', async () => {
-    jest.spyOn(whatsappService, 'getProfilePicUrl').mockResolvedValue(null);
+  test('atualizarFotoDoPedido salva avatar padrão', async () => {
     jest.spyOn(pedidoService, 'getPedidoById').mockResolvedValue({ id: 2, telefone: '11987654321' });
     const updateSpy = jest.spyOn(pedidoService, 'updateCamposPedido').mockResolvedValue({ changes: 1 });
 
@@ -29,8 +26,8 @@ describe('pedido creation and update with profile picture failure', () => {
 
     await pedidosController.atualizarFotoDoPedido(req, res);
 
-    expect(updateSpy).not.toHaveBeenCalled();
+    expect(updateSpy).toHaveBeenCalledWith({}, 2, { fotoPerfilUrl: whatsappService.DEFAULT_AVATAR_URL }, 1);
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ message: 'Nenhuma foto de perfil foi encontrada para este contato.', data: { fotoUrl: null } });
+    expect(res.json).toHaveBeenCalledWith({ message: 'Foto de perfil atualizada com sucesso!', data: { fotoUrl: whatsappService.DEFAULT_AVATAR_URL } });
   });
 });


### PR DESCRIPTION
## Summary
- stop fetching WhatsApp profile pictures
- use a symbolic avatar for all contacts
- adjust photo update route
- update tests for new default avatar

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876896ed2dc83219fa37975ac721d2f