### PR TITLE
Fix sendVideo handler for Venom

### DIFF
--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -70,7 +70,10 @@ async function sendVideo(client, telefone, videoUrl, caption = '') {
     const numeroNormalizado = normalizeTelefone(telefone);
     const numeroFormatado = `${numeroNormalizado}@c.us`;
     const filePath = resolveMediaPath(videoUrl);
-    await client.sendVideo(numeroFormatado, filePath, caption);
+    const fileName = path.basename(filePath);
+    // Venom-bot não possui um método dedicado para envio de vídeo.
+    // Utilizamos sendFile, que trata o MIME e envia o arquivo como vídeo.
+    await client.sendFile(numeroFormatado, filePath, fileName, caption);
 }
 
 /**


### PR DESCRIPTION
## Summary
- use `sendFile` to send videos because Venom does not expose `sendVideo`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687690063f508321a93122599d40dd7d