### PR TITLE
Serve html without extension

### DIFF
--- a/public/login.js
+++ b/public/login.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Se o utilizador já está logado, vai para o painel principal
     if (localStorage.getItem('token')) {
-        window.location.href = '/index.html';
+        window.location.href = '/painel';
         return;
     }
 
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (info.precisa_trocar_senha) {
                 window.location.href = '/change-password.html';
             } else {
-                window.location.href = '/index.html';
+                window.location.href = '/painel';
             }
         } catch (err) {
             displayError(err.message);

--- a/src/app.js
+++ b/src/app.js
@@ -48,7 +48,7 @@ function createExpressApp(db, sessionManager) {
   app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'public', 'landing.html'));
   });
-  app.use(express.static('public'));
+  app.use(express.static('public', { extensions: ['html'] }));
 
   app.use((req, res, next) => {
     req.db = db;
@@ -83,6 +83,10 @@ function createExpressApp(db, sessionManager) {
 
   app.get('/admin', (req, res) => {
     res.sendFile(path.join(__dirname, '..', 'public', 'admin.html'));
+  });
+
+  app.get('/painel', (req, res) => {
+    res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
   });
 
   app.get('/api/teste-conexao', (req, res) => {


### PR DESCRIPTION
## Summary
- serve static HTML files without extension
- map `/painel` to `index.html`
- redirect login success to `/painel`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876cac8655c8321827f435db705f648