### PR TITLE
Adjust login/register routes

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
     const token = localStorage.getItem('token');
-    if (!token) { window.location.href = '/login.html'; return; }
+    if (!token) { window.location.href = '/login'; return; }
 
     const authFetch = (url, options = {}) => {
         options.headers = options.headers || {};
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return fetch(url, options).then(resp => {
             if (resp.status === 401) {
                 localStorage.removeItem('token');
-                window.location.href = '/login.html';
+                window.location.href = '/login';
             }
             return resp;
         });

--- a/public/change-password.js
+++ b/public/change-password.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const token = localStorage.getItem('token');
     if (!token) {
-        window.location.href = '/login.html';
+        window.location.href = '/login';
         return;
     }
 
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             localStorage.removeItem('token');
             alert('Senha atualizada com sucesso! Por favor, faça o login novamente.');
-            window.location.href = '/login.html';
+            window.location.href = '/login';
         } catch (err) {
             displayError(err.message || 'Falha ao atualizar a senha.');
         } finally {

--- a/public/landing.html
+++ b/public/landing.html
@@ -25,8 +25,8 @@
                 <a href="#contact" class="nav-link">Contato</a>
 
                 <div class="nav-actions">
-                    <a href="/login.html" class="btn btn-nav-secondary">Entrar</a>
-                    <a href="/register.html" class="btn btn-nav-primary">Começar Grátis</a>
+                    <a href="/login" class="btn btn-nav-secondary">Entrar</a>
+                    <a href="/register" class="btn btn-nav-primary">Começar Grátis</a>
                 </div>
             </div>
             <div class="nav-toggle">
@@ -493,7 +493,7 @@
                 <h2>Não Deixe a Ansiedade do Cliente Frear Suas Vendas</h2>
                 <p>Chega de perder tempo e dinheiro com problemas de pós-venda. O WhatsShip é a ferramenta que você precisa para escalar seu negócio de encapsulados, fidelizar clientes e construir uma reputação impecável.</p>
                 <div class="cta-buttons">
-                    <a href="/register.html" class="btn btn-primary btn-large">
+                    <a href="/register" class="btn btn-primary btn-large">
                         <span>Começar Agora - Grátis</span>
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M5 12H19M19 12L12 5M19 12L12 19" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/login.html
+++ b/public/login.html
@@ -38,7 +38,7 @@
                 <span class="button-text">Entrar</span>
                 <span class="loader hidden"></span>
             </button>
-            <p class="form-link">Ainda não tem conta? <a href="/register.html">Registe-se aqui</a></p>
+            <p class="form-link">Ainda não tem conta? <a href="/register">Registe-se aqui</a></p>
         </form>
     </div>
     <script src="login.js"></script>

--- a/public/register.html
+++ b/public/register.html
@@ -50,7 +50,7 @@
                 <span class="button-text">Criar Conta Grátis</span>
                 <span class="loader hidden"></span>
             </button>
-            <p class="form-link">Já tem uma conta? <a href="/login.html">Faça login</a></p>
+            <p class="form-link">Já tem uma conta? <a href="/login">Faça login</a></p>
         </form>
     </div>
     <script src="register.js"></script>

--- a/public/register.js
+++ b/public/register.js
@@ -119,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
             
             // Redireciona para o login após um breve momento
             setTimeout(() => {
-                window.location.href = '/login.html';
+                window.location.href = '/login';
             }, 1500);
 
         } catch (err) {

--- a/public/script.js
+++ b/public/script.js
@@ -141,7 +141,7 @@ function capitalize(s) {
 
 document.addEventListener('DOMContentLoaded', () => {
 const token = localStorage.getItem('token');
-if (!token) { window.location.href = '/login.html'; return; }
+if (!token) { window.location.href = '/login'; return; }
 function parseJwt(t){try{return JSON.parse(atob(t.split('.')[1]));}catch(e){return {};}}
 const userData = parseJwt(token);
 if (userData.precisa_trocar_senha) {
@@ -155,7 +155,7 @@ const authFetch = async (url, options = {}) => {
     const resp = await fetch(url, options);
     if (resp.status === 401) {
         localStorage.removeItem('token');
-        window.location.href = '/login.html';
+        window.location.href = '/login';
     }
     if (resp.status === 403) {
         try {
@@ -1505,7 +1505,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
                     if (!resp.ok) throw new Error(data.error || 'Falha ao excluir conta.');
                     localStorage.removeItem('token');
                     alert('Conta excluída com sucesso.');
-                    window.location.href = '/login.html';
+                    window.location.href = '/login';
                 } catch (err) {
                     showNotification(err.message, 'error');
                 }
@@ -1700,7 +1700,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
     if (logoutBtnEl) {
         logoutBtnEl.addEventListener('click', () => {
             localStorage.removeItem('token');
-            window.location.href = '/login.html';
+            window.location.href = '/login';
         });
     }
 

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -7,7 +7,7 @@ async function sendWelcomeEmail(to, password) {
         logger.warn('RESEND_API_KEY não configurada. O e-mail de boas-vindas não será enviado.');
         return;
     }
-    const loginUrl = (process.env.APP_URL || 'http://localhost:3000') + '/login.html';
+    const loginUrl = (process.env.APP_URL || 'http://localhost:3000') + '/login';
 
     const html = `
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- update HTML files and scripts to use `/login` and `/register` paths
- tweak welcome email to link to `/login`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876de85245c83219a6e7eb254c2610a