### PR TITLE
Atualiza limites e preços dos planos

### DIFF
--- a/public/landing.html
+++ b/public/landing.html
@@ -369,11 +369,11 @@
                     </div>
                     <div class="pricing-price">
                         <span class="price-currency">R$</span>
-                        <span class="price-amount">39,99</span>
+                        <span class="price-amount">49,99</span>
                         <span class="price-period">/mês</span>
                     </div>
                     <ul class="pricing-features">
-                        <li>✅ Até 50 rastreios/mês</li>
+                        <li>✅ Até 31 rastreios/mês</li>
                         <li>✅ Automações de mensagens</li>
                         <li>✅ Suporte via email</li>
                         <li>✅ Dashboard básico</li>
@@ -389,11 +389,11 @@
                     </div>
                     <div class="pricing-price">
                         <span class="price-currency">R$</span>
-                        <span class="price-amount">59,99</span>
+                        <span class="price-amount">99,99</span>
                         <span class="price-period">/mês</span>
                     </div>
                     <ul class="pricing-features">
-                        <li>✅ Até 100 rastreios/mês</li>
+                        <li>✅ Até 75 rastreios/mês</li>
                         <li>✅ Automações de mensagens</li>
                         <li>✅ Relatórios de entrega</li>
                         <li>✅ Suporte via email</li>
@@ -409,11 +409,11 @@
                     </div>
                     <div class="pricing-price">
                         <span class="price-currency">R$</span>
-                        <span class="price-amount">99,99</span>
+                        <span class="price-amount">159,99</span>
                         <span class="price-period">/mês</span>
                     </div>
                     <ul class="pricing-features">
-                        <li>✅ Até 250 rastreios/mês</li>
+                        <li>✅ Até 130 rastreios/mês</li>
                         <li>✅ Automações de mensagens</li>
                         <li>✅ Relatórios de entrega</li>
                         <li>✅ Suporte prioritário</li>

--- a/public/script.js
+++ b/public/script.js
@@ -1105,9 +1105,9 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
                 if (p.name === 'Basic') card.classList.add('popular');
 
                 const features = {
-                    'Start': ['50 pedidos/mês', 'Integrações Básicas', 'Relatórios Simples'],
-                    'Basic': ['100 pedidos/mês', 'Relatórios Padrão', 'Suporte via Email'],
-                    'Pro': ['250 pedidos/mês', 'Relatórios Avançados', 'Suporte Prioritário']
+                    'Start': ['31 pedidos/mês', 'Integrações Básicas', 'Relatórios Simples'],
+                    'Basic': ['75 pedidos/mês', 'Relatórios Padrão', 'Suporte via Email'],
+                    'Pro': ['130 pedidos/mês', 'Relatórios Avançados', 'Suporte Prioritário']
                 }[p.name] || [];
 
                 const featuresHtml = features.map(f => `

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -212,10 +212,10 @@ async function initDb() {
   const count = parseInt(rows[0].count, 10);
   if (count === 0) {
     const defaultPlans = [
-      ['Gr\u00e1tis', 0, 10, null],
-      ['Start', 39.99, 50, 'https://payment.ticto.app/O6073F635'],
-      ['Basic', 59.99, 100, 'https://payment.ticto.app/O8EC5C302'],
-      ['Pro', 99.99, 250, 'https://payment.ticto.app/OEE2CBEAA'],
+      ['Gr\u00e1tis', 0, 5, null],
+      ['Start', 49.99, 31, 'https://payment.ticto.app/O6073F635'],
+      ['Basic', 99.99, 75, 'https://payment.ticto.app/O8EC5C302'],
+      ['Pro', 159.99, 130, 'https://payment.ticto.app/OEE2CBEAA'],
     ];
     for (const p of defaultPlans) {
       await sequelize.query('INSERT INTO plans (name, price, monthly_limit, checkout_url) VALUES (?, ?, ?, ?)', { replacements: p });

--- a/src/services/planService.js
+++ b/src/services/planService.js
@@ -19,7 +19,7 @@ async function ensureFreePlan(tx) {
       await new Promise((resolve, reject) => {
         tx.run(
           'INSERT INTO plans (id, name, price, monthly_limit, checkout_url) VALUES (?, ?, ?, ?, ?)',
-          [1, 'Gr\u00e1tis', 0, 10, null],
+          [1, 'Gr\u00e1tis', 0, 5, null],
           err => {
             if (err) return reject(err);
             resolve();


### PR DESCRIPTION
## Summary
- atualizar limites mensais e valores dos planos cadastrados na base de dados
- ajustar os valores e limites exibidos na landing page
- atualizar descrições de planos disponíveis para upgrade

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c5c3be288321ba913901e20de129