### PR TITLE
Update webhook documentation and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Ao receber um webhook válido, o servidor criará a conta do usuário (caso aind
 Para receber códigos de rastreio automaticamente configure **dois webhooks** na plataforma de vendas (Hotmart, Kiwify, Braip, etc.) apontando para o endpoint abaixo:
 
 ```
-POST https://seu-servidor/api/postback?key=SUA_API_KEY
+POST https://seu-servidor/api/postback/<unique_path>
 ```
 
 1. **Venda Aprovada** (`purchase_approved` ou equivalente) – envia nome, telefone e produto do cliente. O pedido é criado sem código de rastreio.

--- a/public/script.js
+++ b/public/script.js
@@ -748,7 +748,7 @@ const btnCopySetupWebhook = document.getElementById('btn-copy-setup-webhook');
             if (!response.ok) throw new Error('Falha ao buscar chave de API.');
             const data = await response.json();
             const baseUrl = `${window.location.protocol}//${window.location.host}`;
-            const webhookUrl = `${baseUrl}/api/postback?key=${data.apiKey}`;
+            const webhookUrl = `${baseUrl}/api/postback/${data.unique_path}`;
             webhookUrlDisplayEl.textContent = webhookUrl;
             if (inputPostbackSecretEl) inputPostbackSecretEl.value = data.settings && data.settings.postback_secret ? data.settings.postback_secret : '';
         } catch (error) {


### PR DESCRIPTION
## Summary
- correct the webhook example in README
- show the webhook URL using the `unique_path` in `public/script.js`

## Testing
- `npm test` *(fails: jest not found / Chrome download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877efcb32848321afc7c4f69d5083b4