### PR TITLE
Add migration for Pedido tracking fields

### DIFF
--- a/migrations/20250716212704-add-lastChecked-fields.js
+++ b/migrations/20250716212704-add-lastChecked-fields.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('pedidos', 'lastCheckedAt', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+    await queryInterface.addColumn('pedidos', 'statusChangeAt', {
+      type: Sequelize.DATE,
+      allowNull: true
+    });
+    await queryInterface.addColumn('pedidos', 'checkCount', {
+      type: Sequelize.INTEGER,
+      defaultValue: 0
+    });
+    await queryInterface.addColumn('pedidos', 'alertSent', {
+      type: Sequelize.INTEGER,
+      defaultValue: 0
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('pedidos', 'lastCheckedAt');
+    await queryInterface.removeColumn('pedidos', 'statusChangeAt');
+    await queryInterface.removeColumn('pedidos', 'checkCount');
+    await queryInterface.removeColumn('pedidos', 'alertSent');
+  }
+};


### PR DESCRIPTION
## Summary
- add migration to include lastCheckedAt, statusChangeAt, checkCount, and alertSent in `pedidos`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687818a5024c83219f460fb623dd9e8a