### PR TITLE
Add unit tests for helper services and utils

### DIFF
--- a/tests/automationService.test.js
+++ b/tests/automationService.test.js
@@ -1,0 +1,31 @@
+const sqlite3 = require('sqlite3').verbose();
+const automationService = require('../src/services/automationService');
+const DEFAULT_MESSAGES = require('../src/constants/defaultMessages');
+
+function setupDb() {
+  const db = new sqlite3.Database(':memory:');
+  db.serialize(() => {
+    db.run('CREATE TABLE automacoes (gatilho TEXT, cliente_id INTEGER, ativo INTEGER, mensagem TEXT)');
+    db.run('CREATE TABLE automacao_passos (id INTEGER PRIMARY KEY AUTOINCREMENT, gatilho TEXT, cliente_id INTEGER, ordem INTEGER, tipo TEXT, conteudo TEXT, mediaUrl TEXT, createdAt TEXT, updatedAt TEXT)');
+  });
+  return db;
+}
+
+describe('automationService.createDefaultAutomations', () => {
+  test('inserts default automations and steps', async () => {
+    const db = setupDb();
+    await automationService.createDefaultAutomations(db, 1);
+
+    const automacoes = await new Promise((resolve, reject) => {
+      db.all('SELECT * FROM automacoes', (err, rows) => err ? reject(err) : resolve(rows));
+    });
+    expect(automacoes).toHaveLength(Object.keys(DEFAULT_MESSAGES).length);
+
+    const passos = await new Promise((resolve, reject) => {
+      db.all('SELECT * FROM automacao_passos', (err, rows) => err ? reject(err) : resolve(rows));
+    });
+    expect(passos).toHaveLength(Object.keys(DEFAULT_MESSAGES).length);
+    expect(passos.every(p => p.tipo === 'texto')).toBe(true);
+    db.close();
+  });
+});

--- a/tests/messageUtils.test.js
+++ b/tests/messageUtils.test.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+const { processIncomingMessage } = require('../src/utils/messageUtils');
+
+describe('processIncomingMessage', () => {
+  const uploadDir = path.join(__dirname, '..', 'public', 'uploads');
+
+  beforeEach(() => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {});
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('handles media message', async () => {
+    const client = { decryptFile: jest.fn().mockResolvedValue(Buffer.from('hi')) };
+    const message = { isMedia: true, type: 'image', mimetype: 'image/png', body: '', caption: 'cap' };
+
+    const result = await processIncomingMessage(client, message);
+
+    const expectedPath = path.join(uploadDir, 'media_1000.png');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, Buffer.from('hi'));
+    expect(result).toEqual({ messageContent: 'cap', messageType: 'image', mediaUrl: '/uploads/media_1000.png' });
+  });
+
+  test('handles audio ptt without caption', async () => {
+    const client = { decryptFile: jest.fn().mockResolvedValue(Buffer.from('audio')) };
+    const message = { isMedia: true, type: 'ptt', mimetype: 'audio/ogg', body: '' };
+
+    const result = await processIncomingMessage(client, message);
+
+    const expectedPath = path.join(uploadDir, 'audio_1000.ogg');
+    expect(fs.writeFileSync).toHaveBeenCalledWith(expectedPath, Buffer.from('audio'));
+    expect(result).toEqual({ messageContent: '[ÁUDIO]', messageType: 'audio', mediaUrl: '/uploads/audio_1000.ogg' });
+  });
+
+  test('handles decrypt errors gracefully', async () => {
+    const client = { decryptFile: jest.fn().mockRejectedValue(new Error('fail')) };
+    const message = { isMedia: true, type: 'image', mimetype: 'image/png', body: 'hello' };
+
+    const result = await processIncomingMessage(client, message);
+
+    expect(result).toEqual({ messageContent: '[MÍDIA NÃO BAIXADA] hello', messageType: 'texto', mediaUrl: null });
+  });
+});

--- a/tests/subscriptionService.test.js
+++ b/tests/subscriptionService.test.js
@@ -1,0 +1,57 @@
+const sqlite3 = require('sqlite3').verbose();
+const moment = require('moment');
+const subscriptionService = require('../src/services/subscriptionService');
+
+function setupDb() {
+  const db = new sqlite3.Database(':memory:');
+  db.serialize(() => {
+    db.run('CREATE TABLE subscriptions (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER, usage INTEGER, renewal_date TEXT)');
+    db.run('CREATE TABLE pedidos (id INTEGER PRIMARY KEY AUTOINCREMENT, cliente_id INTEGER, checkCount INTEGER)');
+  });
+  return db;
+}
+
+describe('subscriptionService.resetUsageIfNeeded', () => {
+  test('resets usage and check count when renewal is due', async () => {
+    const db = setupDb();
+    const past = moment().subtract(1, 'day').format('YYYY-MM-DD');
+    db.run('INSERT INTO subscriptions (id, user_id, usage, renewal_date) VALUES (1, 1, 5, ?)', [past]);
+    db.run('INSERT INTO pedidos (cliente_id, checkCount) VALUES (1, 3)');
+
+    await subscriptionService.resetUsageIfNeeded(db, 1);
+
+    const sub = await new Promise((resolve, reject) => {
+      db.get('SELECT usage, renewal_date FROM subscriptions WHERE id = 1', (e, row) => e ? reject(e) : resolve(row));
+    });
+    expect(sub.usage).toBe(0);
+    const next = moment().add(1, 'month').startOf('day').format('YYYY-MM-DD');
+    expect(sub.renewal_date).toBe(next);
+
+    const pedido = await new Promise((resolve, reject) => {
+      db.get('SELECT checkCount FROM pedidos WHERE cliente_id = 1', (e, row) => e ? reject(e) : resolve(row));
+    });
+    expect(pedido.checkCount).toBe(0);
+    db.close();
+  });
+
+  test('does nothing when renewal date is in the future', async () => {
+    const db = setupDb();
+    const future = moment().add(5, 'days').format('YYYY-MM-DD');
+    db.run('INSERT INTO subscriptions (id, user_id, usage, renewal_date) VALUES (2, 2, 4, ?)', [future]);
+    db.run('INSERT INTO pedidos (cliente_id, checkCount) VALUES (2, 2)');
+
+    await subscriptionService.resetUsageIfNeeded(db, 2);
+
+    const sub = await new Promise((resolve, reject) => {
+      db.get('SELECT usage, renewal_date FROM subscriptions WHERE id = 2', (e, row) => e ? reject(e) : resolve(row));
+    });
+    expect(sub.usage).toBe(4);
+    expect(sub.renewal_date).toBe(future);
+
+    const pedido = await new Promise((resolve, reject) => {
+      db.get('SELECT checkCount FROM pedidos WHERE cliente_id = 2', (e, row) => e ? reject(e) : resolve(row));
+    });
+    expect(pedido.checkCount).toBe(2);
+    db.close();
+  });
+});

--- a/tests/whatsappService.test.js
+++ b/tests/whatsappService.test.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const whatsappService = require('../src/services/whatsappService');
+
+describe('whatsappService helper functions', () => {
+  test('sendImage formats number and resolves path', async () => {
+    const client = { sendImage: jest.fn().mockResolvedValue() };
+    const phone = '11987654321';
+    const imgUrl = '/uploads/test.png';
+    await whatsappService.sendImage(client, phone, imgUrl, 'hello');
+
+    const expectedPath = path.join(__dirname, '..', 'public', 'uploads', 'test.png');
+    expect(client.sendImage).toHaveBeenCalledWith('5511987654321@c.us', expectedPath, 'test.png', 'hello');
+  });
+
+  test('sendAudio formats number and passes url', async () => {
+    const client = { sendVoice: jest.fn().mockResolvedValue() };
+    const phone = '11987654321';
+    const audioUrl = 'http://example.com/audio.ogg';
+
+    await whatsappService.sendAudio(client, phone, audioUrl);
+
+    expect(client.sendVoice).toHaveBeenCalledWith('5511987654321@c.us', audioUrl);
+  });
+});


### PR DESCRIPTION
## Summary
- test whatsappService helpers
- test automationService.createDefaultAutomations
- test subscriptionService.resetUsageIfNeeded
- test messageUtils.processIncomingMessage

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687824fe9aec8321adae222e35449f90