### PR TITLE
Refactor phone normalization utility

### DIFF
--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -11,6 +11,7 @@ const ffmpeg = require('fluent-ffmpeg');
 const ffmpegPath = require('ffmpeg-static');
 ffmpeg.setFfmpegPath(ffmpegPath);
 
+const { normalizeTelefone } = require('../utils/normalizeTelefone');
 const uploadDir = path.join(__dirname, '..', '..', 'public', 'uploads');
 if (!fs.existsSync(uploadDir)) {
     fs.mkdirSync(uploadDir, { recursive: true });
@@ -79,26 +80,6 @@ exports.listarPedidos = (req, res) => {
     });
 };
 
-// Normalizador de telefone
-function normalizeTelefone(telefoneRaw) {
-    if (!telefoneRaw) return null;
-    let digitos = String(telefoneRaw).replace(/\D/g, '');
-    if (digitos.startsWith('55')) {
-        digitos = digitos.substring(2);
-    }
-    if (digitos.length < 10 || digitos.length > 11) {
-        return null;
-    }
-    const ddd = digitos.substring(0, 2);
-    let numero = digitos.substring(2);
-    if (numero.length === 8 && ['6', '7', '8', '9'].includes(numero[0])) {
-        numero = '9' + numero;
-    }
-    if (numero.length !== 9) {
-        return null;
-    }
-    return `55${ddd}${numero}`;
-}
 
 // CRIA um novo pedido
 exports.criarPedido = [

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -1,46 +1,7 @@
 // --- CORREÇÃO: Importando o whatsappService ---
 const whatsappService = require('./whatsappService');
 const logger = require('../logger');
-
-/**
- * NORMALIZADOR DE TELEFONE DEFINITIVO (trata o 9º dígito)
- * Converte qualquer número de celular brasileiro para o formato padrão 55DDD9XXXXXXXX.
- * @param {string} telefoneRaw O número em qualquer formato.
- * @returns {string|null} O número 100% normalizado ou nulo se for inválido.
- */
-function normalizeTelefone(telefoneRaw) {
-    if (!telefoneRaw) return null;
-    // 1. Remove tudo que não for dígito
-    let digitos = String(telefoneRaw).replace(/\D/g, '');
-
-    // 2. Se tiver '55' no início, remove para analisar o número local
-    if (digitos.startsWith('55')) {
-        digitos = digitos.substring(2);
-    }
-
-    // 3. Um número local válido no Brasil tem 10 (DDD+8) ou 11 (DDD+9) dígitos
-    if (digitos.length < 10 || digitos.length > 11) {
-        return null; // Formato inválido
-    }
-
-    const ddd = digitos.substring(0, 2);
-    let numeroBase = digitos.substring(2);
-
-    // 4. A MÁGICA: Se o número base tem 8 dígitos e é um celular, adiciona o '9'
-    if (numeroBase.length === 8 && ['6','7','8','9'].includes(numeroBase[0])) {
-        numeroBase = '9' + numeroBase;
-    }
-
-    // 5. Se o número final não tem 9 dígitos, não é um celular válido
-    if (numeroBase.length !== 9) {
-        return null;
-    }
-
-    // 6. Retorna o número no formato canônico e garantido
-    return `55${ddd}${numeroBase}`;
-}
-
-
+const { normalizeTelefone } = require("../utils/normalizeTelefone");
 /**
  * Busca todos os pedidos do banco de dados.
  */

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -1,6 +1,7 @@
 // --- FUNÇÕES DE AJUDA ---
 const path = require('path');
 
+const { normalizeTelefone } = require("../utils/normalizeTelefone");
 function resolveMediaPath(url) {
     if (!url) return url;
     if (url.startsWith('/uploads/') || url.startsWith('uploads/')) {
@@ -8,22 +9,6 @@ function resolveMediaPath(url) {
     }
     return url;
 }
-
-/**
- * Normaliza um número de telefone para o formato internacional brasileiro (55 + DDD + Número).
- */
-function normalizeTelefone(telefoneRaw) {
-    if (!telefoneRaw) return '';
-    const digitos = String(telefoneRaw).replace(/\D/g, '');
-    if (digitos.startsWith('55') && (digitos.length === 12 || digitos.length === 13)) {
-        return digitos;
-    }
-    if (digitos.length === 10 || digitos.length === 11) {
-        return `55${digitos}`;
-    }
-    return digitos;
-}
-
 // Avatar padrão usado para todos os contatos
 const DEFAULT_AVATAR_URL = 'https://i.imgur.com/z28n3Nz.png';
 

--- a/src/utils/normalizeTelefone.js
+++ b/src/utils/normalizeTelefone.js
@@ -1,0 +1,39 @@
+/**
+ * NORMALIZADOR DE TELEFONE DEFINITIVO (trata o 9\u00ba d\u00edgito)
+ * Converte qualquer n\u00famero de celular brasileiro para o formato padr\u00e3o 55DDD9XXXXXXX.
+ * @param {string} telefoneRaw O n\u00famero em qualquer formato.
+ * @returns {string|null} O n\u00famero 100% normalizado ou nulo se for inv\u00e1lido.
+ */
+function normalizeTelefone(telefoneRaw) {
+    if (!telefoneRaw) return null;
+    // Remove tudo que n\u00e3o for d\u00edgito
+    let digitos = String(telefoneRaw).replace(/\D/g, '');
+
+    // Se tiver '55' no in\u00edcio, remove para analisar o n\u00famero local
+    if (digitos.startsWith('55')) {
+        digitos = digitos.substring(2);
+    }
+
+    // Um n\u00famero local v\u00e1lido no Brasil tem 10 (DDD+8) ou 11 (DDD+9) d\u00edgitos
+    if (digitos.length < 10 || digitos.length > 11) {
+        return null; // Formato inv\u00e1lido
+    }
+
+    const ddd = digitos.substring(0, 2);
+    let numeroBase = digitos.substring(2);
+
+    // Se o n\u00famero base tem 8 d\u00edgitos e \u00e9 um celular, adiciona o '9'
+    if (numeroBase.length === 8 && ['6','7','8','9'].includes(numeroBase[0])) {
+        numeroBase = '9' + numeroBase;
+    }
+
+    // Se o n\u00famero final n\u00e3o tem 9 d\u00edgitos, n\u00e3o \u00e9 um celular v\u00e1lido
+    if (numeroBase.length !== 9) {
+        return null;
+    }
+
+    // Retorna o n\u00famero no formato can\u00f4nico e garantido
+    return `55${ddd}${numeroBase}`;
+}
+
+module.exports = { normalizeTelefone };

--- a/tests/normalizeTelefone.test.js
+++ b/tests/normalizeTelefone.test.js
@@ -1,4 +1,5 @@
-const { normalizeTelefone } = require('../src/services/pedidoService');
+const { normalizeTelefone } = require('../src/utils/normalizeTelefone');
+const pedidoService = require('../src/services/pedidoService');
 
 describe('normalizeTelefone', () => {
   test('normalizes various formats', () => {
@@ -10,5 +11,9 @@ describe('normalizeTelefone', () => {
 
   test('returns null for invalid numbers', () => {
     expect(normalizeTelefone('12345')).toBeNull();
+  });
+
+  test('pedidoService exports the shared implementation', () => {
+    expect(pedidoService.normalizeTelefone).toBe(normalizeTelefone);
   });
 });


### PR DESCRIPTION
## Summary
- move telefone normalization to `src/utils/normalizeTelefone.js`
- reuse this utility in `pedidoService`, `pedidosController` and `whatsappService`
- update tests for new util and ensure service re-exports it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687824fcd8f8832192ce559b836d47c9