### PR TITLE
Add tests for adaptive polling logic

### DIFF
--- a/src/controllers/rastreamentoController.js
+++ b/src/controllers/rastreamentoController.js
@@ -104,5 +104,5 @@ async function verificarRastreios(db, client, clienteId, broadcast) {
     }
 }
 
-module.exports = { verificarRastreios };
+module.exports = { verificarRastreios, shouldCheck };
 


### PR DESCRIPTION
## Summary
- export `shouldCheck` for testing
- cover new polling scenarios in `rastreamentoService.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e27c44fc83218bee9b84b030b6e7