### PR TITLE
Add sqlite pool config

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -204,7 +204,12 @@ async function initDb() {
       }
     );
   } else {
-    sequelize = new Sequelize({ dialect: 'sqlite', storage: DB_PATH, logging: false });
+    sequelize = new Sequelize({
+      dialect: 'sqlite',
+      storage: DB_PATH,
+      logging: false,
+      pool: { max: 1 }
+    });
   }
 
   await sequelize.authenticate();


### PR DESCRIPTION
## Summary
- configure sqlite Sequelize connection to use a one-connection pool

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6879418c1c808321ac033ca41a476cdf