### PR TITLE
Add database close helper and script cleanup

### DIFF
--- a/criar-admin.js
+++ b/criar-admin.js
@@ -37,6 +37,6 @@ const userService = require('./src/services/userService');
     console.error('Erro ao processar:', err);
   } finally {
     rl.close();
-    db.close();
+    await db.close();
   }
 })();

--- a/limpar-usuarios.js
+++ b/limpar-usuarios.js
@@ -23,6 +23,6 @@ const { initDb } = require('./src/database/database');
     await run('ROLLBACK').catch(() => {});
     console.error('Erro ao limpar banco de dados:', err);
   } finally {
-    db.close();
+    await db.close();
   }
 })();

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -45,7 +45,10 @@ function createWrapper(sequelize) {
         finalize(cb) { if (cb) cb(); }
       };
     },
-    serialize(cb) { if (cb) cb(); }
+    serialize(cb) { if (cb) cb(); },
+    close() {
+      return sequelize.close();
+    }
   };
 }
 


### PR DESCRIPTION
## Summary
- add `close()` to DB wrapper
- update CLI scripts to await connection close

## Testing
- `npm test -- --passWithNoTests`
- `node limpar-usuarios.js`

------
https://chatgpt.com/codex/tasks/task_e_68794192731c83218c1b9b252c02785d