### PR TITLE
Add migration script for SQLite to PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,20 @@ node criar-admin.js
 
 Ele irá perguntar o e-mail e, se o usuário não existir, será criado como administrador. Caso já exista, você poderá promovê-lo.
 
+### 3. Migrar do SQLite para PostgreSQL
+
+Caso tenha iniciado o projeto com o banco SQLite e deseje mover os dados para um
+banco PostgreSQL configurado no `.env`, utilize o script abaixo. Certifique-se
+de que as tabelas já existam no banco de destino (execute `npm run migrate` ou
+inicie o servidor uma vez) e que as variáveis `POSTGRES_*` estejam corretas.
+
+```bash
+node scripts/migrateSqliteToPostgres.js
+```
+
+O script exporta cada tabela do SQLite para CSV e importa os registros usando o
+`psql`. Nenhuma informação original é apagada.
+
 ---
 
 ## 📚 Estrutura do Projeto

--- a/scripts/migrateSqliteToPostgres.js
+++ b/scripts/migrateSqliteToPostgres.js
@@ -1,0 +1,47 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+const sqlitePath = process.env.DB_PATH || path.join(__dirname, '../whatsship.db');
+const exportDir = path.join(__dirname, '../tmp_sqlite_export');
+
+const pgUser = process.env.POSTGRES_USER || 'botuser';
+const pgPass = process.env.POSTGRES_PASSWORD || 'botpass';
+const pgDb   = process.env.POSTGRES_DB || 'botdb';
+const pgHost = process.env.POSTGRES_HOST || 'localhost';
+const pgPort = process.env.POSTGRES_PORT || 5432;
+
+function run(cmd, env = {}) {
+  console.log('$ ' + cmd);
+  execSync(cmd, { stdio: 'inherit', env: { ...process.env, ...env }, shell: true });
+}
+
+if (!fs.existsSync(sqlitePath)) {
+  console.error(`SQLite database not found at ${sqlitePath}`);
+  process.exit(1);
+}
+
+fs.rmSync(exportDir, { recursive: true, force: true });
+fs.mkdirSync(exportDir, { recursive: true });
+
+const tablesOutput = execSync(`sqlite3 ${sqlitePath} ".tables"`).toString().trim();
+if (!tablesOutput) {
+  console.error('No tables found in the SQLite database.');
+  process.exit(1);
+}
+const tables = tablesOutput.split(/\s+/).filter(Boolean);
+console.log('Tables:', tables.join(', '));
+
+for (const table of tables) {
+  const csvPath = path.join(exportDir, `${table}.csv`);
+  execSync(`sqlite3 -csv -header ${sqlitePath} "SELECT * FROM \"${table}\";" > ${csvPath}`);
+
+  const pragma = execSync(`sqlite3 ${sqlitePath} "PRAGMA table_info(\"${table}\");"`).toString().trim();
+  const columns = pragma.split('\n').map(l => l.split('|')[1]);
+  const colList = columns.map(c => `\"${c}\"`).join(', ');
+  const copyCmd = `psql -h ${pgHost} -p ${pgPort} -U ${pgUser} -d ${pgDb} -c \"\\copy ${table} (${colList}) FROM '${csvPath}' WITH (FORMAT csv, HEADER true)\"`;
+  run(copyCmd, { PGPASSWORD: pgPass });
+}
+
+console.log('Migration finished.');


### PR DESCRIPTION
## Summary
- add `scripts/migrateSqliteToPostgres.js` script
- document DB migration usage in README

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6879525d98dc8321b08c1a6de6618c22