### PR TITLE
Require JWT_SECRET in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cp .env.example .env
 ```
 
 Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são:
-- `JWT_SECRET` – chave usada para assinar os tokens JWT
+- `JWT_SECRET` – **obrigatório**. Chave usada para assinar os tokens JWT. O servidor não inicia se ela estiver vazia
 - `SITERASTREIO_API_KEY` – chave da API do Site Rastreio
 - `TICTO_SECRET` – token para validar os webhooks da Ticto (enviado no header `X-Ticto-Token`)
 - `PORT` – porta em que o servidor irá rodar (padrão 3000)

--- a/server.js
+++ b/server.js
@@ -1,4 +1,8 @@
 require('dotenv').config();
+
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 const http = require('http');
 const { initDb } = require('./src/database/database');
 const logger = require('./src/logger');
@@ -11,7 +15,7 @@ const { createExpressApp } = require('./src/app');
 let db;
 
 const PORT = process.env.PORT || 3000;
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+const JWT_SECRET = process.env.JWT_SECRET;
 
 async function start() {
   try {

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,5 +1,9 @@
 const jwt = require('jsonwebtoken');
-const JWT_SECRET = process.env.JWT_SECRET || 'secret';
+
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+    throw new Error('JWT_SECRET environment variable is required');
+}
 
 module.exports = (req, res, next) => {
     const authHeader = req.headers.authorization;


### PR DESCRIPTION
## Summary
- ensure JWT_SECRET is configured in `server.js` and auth middleware
- document the requirement in README

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687e12060af88321949f34e0b7136891