### PR TITLE
Fix automacoes migration when columns exist

### DIFF
--- a/migrations/20250712100000-add-media-fields-to-automacoes.js
+++ b/migrations/20250712100000-add-media-fields-to-automacoes.js
@@ -3,19 +3,26 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up (queryInterface, Sequelize) {
-    await queryInterface.addColumn('automacoes', 'tipo_midia', {
-      type: Sequelize.STRING,
-      allowNull: false,
-      defaultValue: 'texto'
-    });
-    await queryInterface.addColumn('automacoes', 'url_midia', {
-      type: Sequelize.STRING,
-      allowNull: true
-    });
-    await queryInterface.addColumn('automacoes', 'legenda_midia', {
-      type: Sequelize.STRING,
-      allowNull: true
-    });
+    const table = await queryInterface.describeTable('automacoes');
+    if (!table.tipo_midia) {
+      await queryInterface.addColumn('automacoes', 'tipo_midia', {
+        type: Sequelize.STRING,
+        allowNull: false,
+        defaultValue: 'texto'
+      });
+    }
+    if (!table.url_midia) {
+      await queryInterface.addColumn('automacoes', 'url_midia', {
+        type: Sequelize.STRING,
+        allowNull: true
+      });
+    }
+    if (!table.legenda_midia) {
+      await queryInterface.addColumn('automacoes', 'legenda_midia', {
+        type: Sequelize.STRING,
+        allowNull: true
+      });
+    }
   },
 
   async down (queryInterface, Sequelize) {


### PR DESCRIPTION
## Summary
- avoid crashing migration when columns already exist in the `automacoes` table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e2315bb608321abf3ebaad167e9b1