### PR TITLE
Switch to async write for media downloads

### DIFF
--- a/src/utils/messageUtils.js
+++ b/src/utils/messageUtils.js
@@ -25,7 +25,7 @@ async function processIncomingMessage(client, message) {
       const prefix = message.type === 'ptt' ? 'audio' : 'media';
       const fileName = `${prefix}_${Date.now()}.${ext}`;
       const filePath = path.join(uploadDir, fileName);
-      fs.writeFileSync(filePath, buffer);
+      await fs.promises.writeFile(filePath, buffer);
       mediaUrl = `/uploads/${fileName}`;
       messageContent = message.caption || (message.type === 'ptt' ? '[ÁUDIO]' : '');
       messageType = message.type === 'ptt' ? 'audio' : message.type;


### PR DESCRIPTION
## Summary
- use `fs.promises.writeFile` instead of `writeFileSync`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e44a82b348321a04b61ef27e23484