### PR TITLE
Rewrite migration script with pg/sqlite3

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ inicie o servidor uma vez) e que as variáveis `POSTGRES_*` estejam corretas.
 node scripts/migrateSqliteToPostgres.js
 ```
 
-O script exporta cada tabela do SQLite para CSV e importa os registros usando o
-`psql`. Nenhuma informação original é apagada.
+O script conecta-se aos bancos SQLite e PostgreSQL utilizando as bibliotecas `sqlite3` e `pg`,
+transferindo cada registro sem remover os dados originais.
 
 ---
 

--- a/scripts/migrateSqliteToPostgres.js
+++ b/scripts/migrateSqliteToPostgres.js
@@ -1,47 +1,78 @@
-const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const { Client } = require('pg');
 require('dotenv').config();
 
 const sqlitePath = process.env.DB_PATH || path.join(__dirname, '../whatsship.db');
-const exportDir = path.join(__dirname, '../tmp_sqlite_export');
 
-const pgUser = process.env.POSTGRES_USER || 'botuser';
-const pgPass = process.env.POSTGRES_PASSWORD || 'botpass';
-const pgDb   = process.env.POSTGRES_DB || 'botdb';
-const pgHost = process.env.POSTGRES_HOST || 'localhost';
-const pgPort = process.env.POSTGRES_PORT || 5432;
+const pgClient = new Client({
+  user: process.env.POSTGRES_USER || 'botuser',
+  password: process.env.POSTGRES_PASSWORD || 'botpass',
+  database: process.env.POSTGRES_DB || 'botdb',
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432', 10)
+});
 
-function run(cmd, env = {}) {
-  console.log('$ ' + cmd);
-  execSync(cmd, { stdio: 'inherit', env: { ...process.env, ...env }, shell: true });
+function sanitizeIdentifier(id) {
+  if (!/^[A-Za-z0-9_]+$/.test(id)) {
+    throw new Error(`Unsafe identifier detected: ${id}`);
+  }
+  return id;
 }
 
-if (!fs.existsSync(sqlitePath)) {
-  console.error(`SQLite database not found at ${sqlitePath}`);
-  process.exit(1);
+async function migrate() {
+  if (!fs.existsSync(sqlitePath)) {
+    console.error(`SQLite database not found at ${sqlitePath}`);
+    process.exit(1);
+  }
+
+  console.log('Connecting to databases...');
+  const sqlite = new sqlite3.Database(sqlitePath);
+  await pgClient.connect();
+
+  const all = (db, sql, params = []) => new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => (err ? reject(err) : resolve(rows)));
+  });
+
+  try {
+    const tableRows = await all(
+      sqlite,
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    );
+    const tables = tableRows.map(r => sanitizeIdentifier(r.name));
+
+    if (tables.length === 0) {
+      console.error('No tables found in the SQLite database.');
+      return;
+    }
+
+    console.log('Tables:', tables.join(', '));
+
+    for (const table of tables) {
+      const columnRows = await all(sqlite, `PRAGMA table_info(\"${table}\")`);
+      const columns = columnRows.map(c => sanitizeIdentifier(c.name));
+      if (columns.length === 0) continue;
+
+      const colList = columns.map(c => `\"${c}\"`).join(', ');
+      const placeholders = columns.map((_, i) => `$${i + 1}`).join(', ');
+      const insertSql = `INSERT INTO \"${table}\" (${colList}) VALUES (${placeholders})`;
+
+      const rows = await all(sqlite, `SELECT * FROM \"${table}\"`);
+      console.log(`Migrating ${table}... (${rows.length} rows)`);
+      for (const row of rows) {
+        const values = columns.map(c => row[c]);
+        await pgClient.query(insertSql, values);
+      }
+    }
+
+    console.log('Migration finished.');
+  } catch (err) {
+    console.error('Migration failed:', err);
+  } finally {
+    sqlite.close();
+    await pgClient.end();
+  }
 }
 
-fs.rmSync(exportDir, { recursive: true, force: true });
-fs.mkdirSync(exportDir, { recursive: true });
-
-const tablesOutput = execSync(`sqlite3 ${sqlitePath} ".tables"`).toString().trim();
-if (!tablesOutput) {
-  console.error('No tables found in the SQLite database.');
-  process.exit(1);
-}
-const tables = tablesOutput.split(/\s+/).filter(Boolean);
-console.log('Tables:', tables.join(', '));
-
-for (const table of tables) {
-  const csvPath = path.join(exportDir, `${table}.csv`);
-  execSync(`sqlite3 -csv -header ${sqlitePath} "SELECT * FROM \"${table}\";" > ${csvPath}`);
-
-  const pragma = execSync(`sqlite3 ${sqlitePath} "PRAGMA table_info(\"${table}\");"`).toString().trim();
-  const columns = pragma.split('\n').map(l => l.split('|')[1]);
-  const colList = columns.map(c => `\"${c}\"`).join(', ');
-  const copyCmd = `psql -h ${pgHost} -p ${pgPort} -U ${pgUser} -d ${pgDb} -c \"\\copy ${table} (${colList}) FROM '${csvPath}' WITH (FORMAT csv, HEADER true)\"`;
-  run(copyCmd, { PGPASSWORD: pgPass });
-}
-
-console.log('Migration finished.');
+migrate();


### PR DESCRIPTION
## Summary
- rewrite `scripts/migrateSqliteToPostgres.js` to use `pg` and `sqlite3`
- update README to describe new migration process

## Testing
- `npm run migrate` *(fails: sequelize-cli not found)*
- `npm install` *(fails: puppeteer download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e44a8bfac83218a9ba1e5bfe6221b