### PR TITLE
Fix IDs when using Postgres

### DIFF
--- a/src/services/integrationService.js
+++ b/src/services/integrationService.js
@@ -1,9 +1,11 @@
 const crypto = require('crypto');
+const DB_CLIENT = process.env.DB_CLIENT || 'sqlite';
 
 function createIntegration(db, userId, platform, name, secretKey = null) {
     return new Promise((resolve, reject) => {
         const unique_path = crypto.randomBytes(16).toString('hex');
-        const sql = 'INSERT INTO integrations (user_id, platform, name, unique_path, secret_key) VALUES (?, ?, ?, ?, ?)';
+        const returning = DB_CLIENT === 'postgres' ? ' RETURNING id' : '';
+        const sql = `INSERT INTO integrations (user_id, platform, name, unique_path, secret_key) VALUES (?, ?, ?, ?, ?)${returning}`;
 
         db.run(sql, [userId, platform, name, unique_path, secretKey], function(err) {
             if (err) return reject(err);

--- a/src/services/logService.js
+++ b/src/services/logService.js
@@ -1,4 +1,5 @@
 const { getModels } = require('../database/database');
+const DB_CLIENT = process.env.DB_CLIENT || 'sqlite';
 
 const addLog = (db, clienteId, acao, detalhe = null, options = {}) => {
     if (options.transaction) {
@@ -6,7 +7,8 @@ const addLog = (db, clienteId, acao, detalhe = null, options = {}) => {
         return Log.create({ cliente_id: clienteId, acao, detalhe }, { transaction: options.transaction });
     }
     return new Promise((resolve, reject) => {
-        const sql = `INSERT INTO logs (cliente_id, acao, detalhe) VALUES (?, ?, ?)`;
+        const returning = DB_CLIENT === 'postgres' ? ' RETURNING id' : '';
+        const sql = `INSERT INTO logs (cliente_id, acao, detalhe) VALUES (?, ?, ?)${returning}`;
         db.run(sql, [clienteId, acao, detalhe], function(err) {
             if (err) return reject(err);
             resolve({ id: this.lastID });

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -156,7 +156,7 @@ const updateCamposPedido = async (db, pedidoId, campos, clienteId = null) => {
  */
 const addMensagemHistorico = (db, pedidoId, mensagem, tipoMensagem, origem, clienteId = null, mediaUrl = null, messageType = 'texto') => {
     return new Promise((resolve, reject) => {
-        const sqlInsert = `INSERT INTO historico_mensagens (pedido_id, cliente_id, mensagem, tipo_mensagem, origem, media_url, message_type) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+        const sqlInsert = `INSERT INTO historico_mensagens (pedido_id, cliente_id, mensagem, tipo_mensagem, origem, media_url, message_type) VALUES (?, ?, ?, ?, ?, ?, ?)${DB_CLIENT === 'postgres' ? ' RETURNING id' : ''}`;
         const sanitizedMessage = (mensagem === undefined || mensagem === null) ? '' : mensagem;
         const params = [pedidoId, clienteId ?? null, sanitizedMessage, tipoMensagem, origem, mediaUrl, messageType];
 
@@ -275,7 +275,7 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
 
         const fotoUrl = await whatsappService.getProfilePicUrl();
 
-        const sql = `INSERT INTO pedidos (cliente_id, nome, email, telefone, produto, ${q('codigoRastreio')}, notas, ${q('fotoPerfilUrl')}, ${q('dataCriacao')}, ${q('lastCheckedAt')}, ${q('statusChangeAt')}, ${q('checkCount')}, ${q('alertSent')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+        const sql = `INSERT INTO pedidos (cliente_id, nome, email, telefone, produto, ${q('codigoRastreio')}, notas, ${q('fotoPerfilUrl')}, ${q('dataCriacao')}, ${q('lastCheckedAt')}, ${q('statusChangeAt')}, ${q('checkCount')}, ${q('alertSent')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)${DB_CLIENT === 'postgres' ? ' RETURNING id' : ''}`;
         const params = [clienteId, nome, email || null, telefoneValidado, produto || null, codigoRastreio || null, notas || null, fotoUrl, new Date().toISOString(), null, null, 0, 0];
 
         db.run(sql, params, function (err) {


### PR DESCRIPTION
## Summary
- append `RETURNING id` when inserting records if running on Postgres
- expose `DB_CLIENT` in more services so they know whether to add `RETURNING`

## Testing
- `node -e "require('./src/services/userService'); require('./src/services/subscriptionService'); require('./src/services/integrationService'); require('./src/services/logService'); require('./src/services/pedidoService'); console.log('loaded');"`

------
https://chatgpt.com/codex/tasks/task_e_687e600597dc8321be446f75a59f9a8a