### PR TITLE
Add ultimaMensagem migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Edite o `.env` com suas chaves e URLs de callback. As principais variáveis são
 
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` e `POSTGRES_HOST` podem ser definidos para usar PostgreSQL em container.
 - `DB_CLIENT` deve ser `postgres` para conectar ao banco no docker-compose.
+
+Após configurar o `.env`, execute as migrações para criar as tabelas:
+
+```bash
+npm run migrate
+```
 ### Usando Docker
 
 ```bash

--- a/migrations/20250717100000-add-ultimaMensagem-fields.js
+++ b/migrations/20250717100000-add-ultimaMensagem-fields.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('pedidos');
+    if (!Object.prototype.hasOwnProperty.call(table, 'ultimaMensagem')) {
+      await queryInterface.addColumn('pedidos', 'ultimaMensagem', {
+        type: Sequelize.STRING,
+        allowNull: true
+      });
+    }
+    if (!Object.prototype.hasOwnProperty.call(table, 'dataUltimaMensagem')) {
+      await queryInterface.addColumn('pedidos', 'dataUltimaMensagem', {
+        type: Sequelize.DATE,
+        allowNull: true
+      });
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('pedidos', 'ultimaMensagem');
+    await queryInterface.removeColumn('pedidos', 'dataUltimaMensagem');
+  }
+};


### PR DESCRIPTION
## Summary
- add migration for ultimaMensagem and dataUltimaMensagem columns
- mention running migrations in README setup instructions

## Testing
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install`
- `npm run migrate -- --help`

------
https://chatgpt.com/codex/tasks/task_e_687e6ca575e4832189fdb5733454410f