### PR TITLE
Reduce Venom logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,28 @@ POST https://seu-servidor/api/postback/<unique_path>
 
 Nosso servidor já reconhece automaticamente webhooks da Hotmart e da Kiwify, convertendo os campos para esse formato padronizado. Em outras plataformas, mantenha os nomes o mais próximo possível do exemplo acima.
 
+## 📝 Logs do Venom e PM2
+
+O Venom costuma imprimir mensagens de status no console, que o PM2 grava em
+`bot-rastreamento-error.log`. Elas não representam erros.
+
+As opções definidas em `src/whatsappSessions.js` já desativam vários desses
+logs (`logQR: false`, `updatesLog: false`, `disableSpins` e `disableWelcome`).
+Se desejar unificar os arquivos de log do PM2, crie um `ecosystem.config.js`
+apontando `error_file` para `/dev/stdout`:
+
+```js
+module.exports = {
+  apps: [{
+    name: 'bot-rastreamento',
+    script: 'server.js',
+    error_file: '/dev/stdout',
+    out_file: '/dev/stdout',
+    merge_logs: true
+  }]
+};
+```
+
 ---
 
 ## ⚖️ Licença

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  apps: [
+    {
+      name: 'bot-rastreamento',
+      script: 'server.js',
+      error_file: '/dev/stdout',
+      out_file: '/dev/stdout',
+      merge_logs: true,
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};

--- a/src/whatsappSessions.js
+++ b/src/whatsappSessions.js
@@ -80,6 +80,11 @@ function createWhatsAppManager(app, { broadcastStatus, broadcastToUser }) {
           headless: 'new',
           browserArgs: ['--no-sandbox', '--disable-setuid-sandbox'],
           puppeteerOptions: { protocolTimeout: 60000 },
+          logQR: false,
+          updatesLog: false,
+          disableSpins: true,
+          disableWelcome: true,
+          debug: false,
         },
         (base64Qr) => broadcastStatus(userId, 'QR_CODE', { qrCode: base64Qr })
       )


### PR DESCRIPTION
## Summary
- suppress Venom startup messages with options in `venom.create`
- document how to combine PM2 logs
- add example `ecosystem.config.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e7bee90e08321b595380635d85ad6