### PR TITLE
Use proper Sequelize transactions

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -45,7 +45,6 @@ function createWrapper(sequelize) {
         finalize(cb) { if (cb) cb(); }
       };
     },
-    serialize(cb) { if (cb) cb(); },
     close() {
       return sequelize.close();
     }


### PR DESCRIPTION
## Summary
- remove unused `serialize` function
- delete orders in a transactional manner
- use Sequelize transactions in automation functions
- reset subscription usage with transactions
- delete users via Sequelize transactions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687eb1a9717c83218e59b6210cb7c40f