### PR TITLE
Sync default Rastreio API key for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ mostra os dados retornados pela API diretamente no terminal:
 node scripts/testRastreamento.js AM123456789BR
 ```
 
+### 5. Sincronizar chave de rastreio para todos os usuários
+
+Se os usuários já foram criados antes de definir `SITERASTREIO_API_KEY`, execute
+o script abaixo para gravar essa chave em todas as contas existentes:
+
+```bash
+node scripts/setRastreioApiKey.js
+```
+
 
 ---
 

--- a/scripts/setRastreioApiKey.js
+++ b/scripts/setRastreioApiKey.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+const { initDb, getModels } = require('../src/database/database');
+
+(async () => {
+  const apiKey = process.env.SITERASTREIO_API_KEY;
+  if (!apiKey) {
+    console.error('Defina SITERASTREIO_API_KEY no .env');
+    process.exit(1);
+  }
+
+  const db = await initDb().catch(err => {
+    console.error('Erro ao conectar ao banco de dados:', err);
+    process.exit(1);
+  });
+
+  const { User, IntegrationSetting } = getModels();
+
+  try {
+    const users = await User.findAll({ attributes: ['id'], raw: true });
+    for (const { id } of users) {
+      await IntegrationSetting.upsert({ user_id: id, rastreio_api_key: apiKey });
+    }
+    console.log(`✅ Chave atribuída para ${users.length} usuários.`);
+  } catch (err) {
+    console.error('Erro ao atualizar chaves:', err.message);
+  } finally {
+    await db.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- store `SITERASTREIO_API_KEY` when creating default integration settings
- add a helper script to assign the tracking key to every existing user
- document the new script in the README

## Testing
- `node --check scripts/setRastreioApiKey.js && node --check src/services/integrationConfigService.js`

------
https://chatgpt.com/codex/tasks/task_e_687ffba2351483218f23e83ecfe8667b