### PR TITLE
Fix status badge visibility for unknown statuses

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1617,6 +1617,7 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     font-size: 0.8em;
     font-weight: bold;
     color: #fff;
+    background-color: #6c757d;
 }
 
 .status-entregue { background-color: #28a745; }


### PR DESCRIPTION
## Summary
- fix default style for `.status-badge` so unknown statuses are visible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880f0d8682883219d70199e5a0f4d19