### PR TITLE
Enhance rastreamento test script output

### DIFF
--- a/scripts/testRastreamento.js
+++ b/scripts/testRastreamento.js
@@ -8,38 +8,49 @@ const { rastrearCodigo } = require('../src/services/rastreamentoService');
   }
 
   try {
-    const resultado = await rastrearCodigo(codigo);
+  const resultado = await rastrearCodigo(codigo);
 
-    const {
-      statusInterno,
-      ultimaLocalizacao,
-      ultimaAtualizacao,
-      origemUltimaMovimentacao,
-      destinoUltimaMovimentacao
-    } = resultado;
+  const {
+    statusInterno,
+    ultimaLocalizacao,
+    ultimaAtualizacao,
+    origemUltimaMovimentacao,
+    destinoUltimaMovimentacao,
+    descricaoUltimoEvento,
+    eventos
+  } = resultado;
 
-    let mensagem = `Código: ${codigo} - Status: ${statusInterno || 'indisponível'}`;
+  const linhas = [];
+  linhas.push(`Código: ${codigo}`);
+  linhas.push(`Status: ${statusInterno || 'indisponível'}`);
 
-    if (origemUltimaMovimentacao && destinoUltimaMovimentacao) {
-      mensagem += `\nSeu pedido saiu de ${origemUltimaMovimentacao} e está a caminho de ${destinoUltimaMovimentacao}.`;
-    } else if (ultimaLocalizacao) {
-      mensagem += `\nÚltima localização conhecida: ${ultimaLocalizacao}.`;
-    }
+  if (origemUltimaMovimentacao && destinoUltimaMovimentacao) {
+    linhas.push(`Seu pedido saiu de ${origemUltimaMovimentacao} e está a caminho de ${destinoUltimaMovimentacao}.`);
+  } else if (ultimaLocalizacao) {
+    linhas.push(`Última localização conhecida: ${ultimaLocalizacao}.`);
+  }
 
-    if (ultimaAtualizacao) {
-      const data = new Date(ultimaAtualizacao);
-      const formatada = !isNaN(data)
-        ? data.toLocaleString('pt-BR', {
-            timeZone: 'America/Sao_Paulo',
-            hour: '2-digit',
-            minute: '2-digit'
-          })
-        : ultimaAtualizacao;
-      mensagem += `\nAtualizado em: ${formatada}`;
-    }
+  if (ultimaAtualizacao) {
+    const data = new Date(ultimaAtualizacao);
+    const formatada = !isNaN(data)
+      ? data.toLocaleString('pt-BR', {
+          timeZone: 'America/Sao_Paulo',
+          hour: '2-digit',
+          minute: '2-digit'
+        })
+      : ultimaAtualizacao;
+    linhas.push(`Atualizado em: ${formatada}`);
+  }
 
-    console.log(mensagem);
-    console.log('\nDados completos:\n', JSON.stringify(resultado, null, 2));
+  if (descricaoUltimoEvento) {
+    linhas.push(`Descrição do último evento: ${descricaoUltimoEvento}`);
+  }
+
+  console.log(linhas.join('\n'));
+  if (eventos) {
+    console.log('\nEventos:', JSON.stringify(eventos, null, 2));
+  }
+  console.log('\nDados completos:\n', JSON.stringify(resultado, null, 2));
   } catch (err) {
     console.error('Erro ao rastrear codigo:', err.message);
   }


### PR DESCRIPTION
## Summary
- improve `testRastreamento.js` to show all tracking data clearly

## Testing
- `node scripts/testRastreamento.js AM718570687BR`

------
https://chatgpt.com/codex/tasks/task_e_68812b5e14e8832184d46d560cf17f53