### PR TITLE
Improve origin/destination extraction

### DIFF
--- a/src/services/rastreamentoService.js
+++ b/src/services/rastreamentoService.js
@@ -56,9 +56,24 @@ async function rastrearCodigo(codigo, apiKey = null) {
             }
         }
 
+        // Fallback quando os dados de origem/destino nao sao encontrados na descricao
+        if (!origem) {
+            origem = ultimoEvento.unidade?.endereco?.cidade || null;
+        }
+
+        if (!destino) {
+            destino = ultimoEvento.unidadeDestino?.endereco?.cidade || null;
+        }
+
+        const ultimaLocalizacao =
+            ultimoEvento.location ||
+            ultimoEvento.unidadeDestino?.endereco?.cidade ||
+            ultimoEvento.unidade?.endereco?.cidade ||
+            '-';
+
         return {
             statusInterno: ultimoEvento.status || ultimoEvento.descricaoFrontEnd || 'Desconhecido',
-            ultimaLocalizacao: ultimoEvento.location || ultimoEvento.unidade?.endereco?.cidade || '-',
+            ultimaLocalizacao: ultimaLocalizacao,
             ultimaAtualizacao: `${ultimoEvento.date || ''} ${ultimoEvento.time || ''}`.trim() || ultimoEvento.dtHrCriado?.date || '-',
             origemUltimaMovimentacao: origem,
             destinoUltimaMovimentacao: destino,


### PR DESCRIPTION
## Summary
- improve fallback logic to get origem and destino from `unidade` and `unidadeDestino` fields
- update last location calculation
- retain message logic for test script

## Testing
- `npm install`
- `node scripts/testRastreamento.js AM123456789BR`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68812ec761bc8321bfa18bc06ac775e4