### PR TITLE
Add manual tracking verification

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -499,6 +499,7 @@
                                         <th>Produto</th>
                                         <th>Código de Rastreio</th>
                                         <th>Status</th>
+                                        <th>Ações</th>
                                     </tr>
                                 </thead>
                                 <tbody id="corpo-tabela-relatorio">
@@ -560,6 +561,16 @@
             <h3 id="modal-aviso-titulo"></h3>
             <p id="modal-aviso-texto"></p>
             <button id="btn-modal-aviso-ok" class="btn-primary" style="width: 100%;">Entendi</button>
+        </div>
+    </div>
+    <div id="modal-verificar" class="modal-overlay">
+        <div class="modal-content">
+            <h3>Detalhes do Rastreio</h3>
+            <div id="verificar-conteudo">A carregar...</div>
+            <div class="modal-acoes">
+                <button type="button" id="btn-verificar-cancelar" class="btn-cancelar">Cancelar</button>
+                <button type="button" id="btn-verificar-enviar" class="btn-salvar">Enviar para o Cliente</button>
+            </div>
         </div>
     </div>
 

--- a/public/style.css
+++ b/public/style.css
@@ -361,6 +361,7 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 #tracking-table tbody tr:nth-child(even) { background-color: var(--hover-bg); }
 #tracking-table tbody tr:last-child td { border-bottom: none; }
 .btn-copy-code { background: none; border: none; cursor: pointer; margin-left: 4px; }
+.btn-verificar { background: none; border: none; color: var(--primary-color); cursor: pointer; text-decoration: underline; }
 .status-badge { padding: 4px 10px; border-radius: 12px; font-size: 0.8rem; font-weight: 600; }
 .status-badge.success { background-color: #dcfce7; color: #166534; }
 .status-badge.error { background-color: #fee2e2; color: #991b1b; }

--- a/src/app.js
+++ b/src/app.js
@@ -149,6 +149,7 @@ function createExpressApp(db, sessionManager) {
   app.post('/api/pedidos/:id/enviar-midia', planCheck, pedidosController.upload.single('file'), pedidosController.enviarMidia);
   app.post('/api/pedidos/:id/atualizar-foto', planCheck, pedidosController.atualizarFotoDoPedido);
   app.put('/api/pedidos/:id/marcar-como-lido', planCheck, pedidosController.marcarComoLido);
+  app.get('/api/pedidos/:id/verificar-rastreio', planCheck, pedidosController.verificarRastreioManual);
 
   app.post('/api/upload', planCheck, uploadController.upload.single('file'), uploadController.uploadFile);
 

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -106,7 +106,7 @@ exports.getClientesComRastreio = async (req, res) => {
 
         const createdAtAlias = DB_CLIENT === 'postgres' ? '"createdAt"' : 'createdAt';
 
-        const sql = `SELECT nome, produto, ${q('codigoRastreio')},
+        const sql = `SELECT id, nome, produto, ${q('codigoRastreio')},
                             ${q('statusInterno')} AS status,
                             ${q('dataCriacao')} AS ${createdAtAlias}
                      FROM pedidos


### PR DESCRIPTION
## Summary
- add new manual tracking route
- update reports to include order IDs
- allow verifying a single tracking code from frontend
- show tracking details in a modal with history

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881383c9b488321af731d7c23d67508