### PR TITLE
Implement tracking timeline in modal

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1951,7 +1951,23 @@ const btnVerificarEnviarEl = document.getElementById('btn-verificar-enviar');
                     <p><strong>Data e Hora da Última Atualização:</strong> ${escapeHtml(data.ultimaAtualizacao || '-')}</p>
                     <p><strong>Localização Atual:</strong> ${escapeHtml(data.ultimaLocalizacao || '-')}</p>
                     <h4>Histórico Completo dos Eventos:</h4>
-                    <ul>${(data.eventos || []).map(ev => `<li>${escapeHtml(ev.date || ev.dtHrCriado || '')} - ${escapeHtml(ev.description || ev.descricao || ev.descricaoFrontEnd || '')} (${escapeHtml(ev.location || ev.unidade?.endereco?.cidade || '')})</li>`).join('')}</ul>
+                    <ul class="timeline">
+                        ${(data.eventos || []).map(ev => {
+                            const rawDate = ev.dtHrCriado?.date || ev.date || ev.dtHrCriado || '';
+                            const d = rawDate ? new Date(rawDate) : null;
+                            const formatted = d && !isNaN(d) ? d.toLocaleString('pt-BR') : rawDate;
+                            return `
+                                <li class="timeline-item">
+                                    <div class="timeline-dot"></div>
+                                    <div class="timeline-date">${escapeHtml(formatted || '-')}</div>
+                                    <div class="timeline-content">
+                                        ${escapeHtml(ev.descricao || ev.description || ev.descricaoFrontEnd || '')}
+                                        <span>Local: ${escapeHtml(ev.unidade?.endereco?.cidade || ev.location || 'N/A')} - ${escapeHtml(ev.unidade?.endereco?.uf || ev.locationUf || 'N/A')}</span>
+                                    </div>
+                                </li>
+                            `;
+                        }).join('')}
+                    </ul>
                 `;
             })
             .catch(err => {

--- a/public/style.css
+++ b/public/style.css
@@ -1835,3 +1835,12 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
     display: inline-block;
     font-size: 0.9rem;
 }
+/* Estilos para a Timeline de Rastreio no Modal */
+.timeline { list-style: none; padding: 0; margin-top: 15px; }
+.timeline-item { position: relative; padding-bottom: 20px; padding-left: 25px; border-left: 2px solid #e5e7eb; }
+.timeline-item:last-child { border-left: 2px solid transparent; padding-bottom: 0; }
+.timeline-dot { position: absolute; left: -9px; top: 4px; width: 16px; height: 16px; background-color: #e5e7eb; border-radius: 50%; }
+.timeline-item:first-child .timeline-dot { background-color: var(--primary-color); }
+.timeline-date { font-size: 0.8rem; color: var(--text-secondary); margin-bottom: 4px; }
+.timeline-content { font-weight: 500; }
+.timeline-content span { display: block; font-weight: 400; color: var(--text-secondary); font-size: 0.9rem; }


### PR DESCRIPTION
## Summary
- style timeline for tracking events
- render tracking events in a timeline in the verify modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68814d63a90083218b311c22cf467381