### PR TITLE
Add send options for tracking modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -573,6 +573,16 @@
             </div>
         </div>
     </div>
+    <div id="modal-opcoes-envio" class="modal-overlay">
+        <div class="modal-content">
+            <h3>Enviar para o Cliente</h3>
+            <div class="modal-acoes" style="justify-content:center; flex-wrap:wrap; gap:10px;">
+                <button type="button" id="btn-enviar-resumo" class="btn-salvar">Enviar Resumo</button>
+                <button type="button" id="btn-enviar-historico" class="btn-salvar">Enviar Histórico Completo</button>
+                <button type="button" id="btn-envio-cancelar" class="btn-cancelar">Cancelar</button>
+            </div>
+        </div>
+    </div>
 
     <script src="script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add second modal with options to send resumo or histórico
- capture tracking data and enable choosing message type
- send formatted WhatsApp message based on chosen option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688150e166f48321aae13caa1a85c969