### PR TITLE
Fix long message storage and name usage

### DIFF
--- a/migrations/20250724100000-change-ultimaMensagem-to-text.js
+++ b/migrations/20250724100000-change-ultimaMensagem-to-text.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('pedidos', 'ultimaMensagem', {
+      type: Sequelize.TEXT,
+      allowNull: true
+    });
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('pedidos', 'ultimaMensagem', {
+      type: Sequelize.STRING,
+      allowNull: true
+    });
+  }
+};

--- a/public/script.js
+++ b/public/script.js
@@ -1780,8 +1780,9 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
     if (btnEnviarResumoEl) btnEnviarResumoEl.addEventListener('click', () => {
         if (!currentTrackingData) return;
 
-        const pedido = todosOsPedidos.find(p => p.id === currentTrackingPedidoId);
-        const primeiroNome = pedido ? pedido.nome.split(' ')[0] : 'Cliente';
+        const pedido = todosOsPedidos.find(p => p.id === currentTrackingPedidoId) ||
+                       trackingDataCache.find(p => p.id === currentTrackingPedidoId);
+        const primeiroNome = pedido && pedido.nome ? pedido.nome.split(' ')[0] : 'Cliente';
 
         let statusPrincipal = '';
         if (currentTrackingData.origemUltimaMovimentacao && currentTrackingData.destinoUltimaMovimentacao) {
@@ -1802,7 +1803,8 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
 
     if (btnEnviarHistoricoEl) btnEnviarHistoricoEl.addEventListener('click', () => {
         if (!currentTrackingData) return;
-        const pedido = todosOsPedidos.find(p => p.id === currentTrackingPedidoId) || {};
+        const pedido = todosOsPedidos.find(p => p.id === currentTrackingPedidoId) ||
+                       trackingDataCache.find(p => p.id === currentTrackingPedidoId) || {};
         const nome = pedido.nome ? pedido.nome.split(' ')[0] : 'Cliente';
         const eventos = (currentTrackingData.eventos || []).map(ev => {
             const rawDate = ev.dtHrCriado?.date || ev.date || ev.dtHrCriado || '';

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -101,7 +101,7 @@ function defineModels(sequelize) {
     fotoPerfilUrl: DataTypes.STRING,
     dataCriacao: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
     mensagensNaoLidas: { type: DataTypes.INTEGER, defaultValue: 0 },
-    ultimaMensagem: DataTypes.STRING,
+    ultimaMensagem: DataTypes.TEXT,
     dataUltimaMensagem: DataTypes.DATE,
     lastCheckedAt: DataTypes.DATE,
     statusChangeAt: DataTypes.DATE,


### PR DESCRIPTION
## Summary
- change `ultimaMensagem` column to TEXT and add migration
- fallback to `trackingDataCache` when resolving client name
- update model definition to TEXT

## Testing
- `npm test` *(fails: Missing script)*
- `npx sequelize-cli db:migrate` *(fails: unable to resolve sequelize package)*

------
https://chatgpt.com/codex/tasks/task_e_688162f6ea048321acb7014bf8e4f1ac