### PR TITLE
Restrict manual tracking to paid plans

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -252,6 +252,8 @@ const authFetch = async (url, options = {}) => {
 const modalUpgradeEl = document.getElementById('modal-upgrade');
 const btnUpgradePlansEl = document.getElementById('btn-upgrade-plans');
 const planStatusEl = document.getElementById('plan-status');
+// Armazena o nome do plano do usuário para controlar funcionalidades
+let userPlanName = 'Grátis';
 const btnImportarCsv = document.getElementById('btn-importar-csv');
 const csvFileInput = document.getElementById('csv-file-input');
 const btnAddIntegration = document.getElementById('btn-add-integration');
@@ -1068,13 +1070,16 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
                     const status = pedido.status || 'indefinido';
                     const statusClass = `status-${status.toLowerCase().replace(/ /g, '-')}`;
 
+                    const isFreePlan = userPlanName === 'Grátis';
+                    const disabledAttribute = isFreePlan ? 'disabled title="Funcionalidade disponível apenas em planos pagos."' : '';
+
                     row.innerHTML = `
                         <td>${formatDate(pedido.createdAt)}</td>
                         <td>${escapeHtml(pedido.nome || '-')}</td>
                         <td>${escapeHtml(pedido.produto || 'Não informado')}</td>
                         <td>${escapeHtml(pedido.codigoRastreio || 'N/A')}</td>
                         <td><span class="status-badge ${statusClass}">${escapeHtml(status)}</span></td>
-                        <td><button class="btn-verificar" data-id="${pedido.id}">Verificar</button></td>
+                        <td><button class="btn-verificar" data-id="${pedido.id}" ${disabledAttribute}>Verificar</button></td>
                     `;
                     tabelaCorpo.appendChild(row);
                 });
@@ -1099,6 +1104,8 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
             const resp = await authFetch('/api/subscription');
             if (!resp.ok) throw new Error('Falha ao carregar assinatura');
             const { subscription } = await resp.json();
+            // Guarda o nome do plano para uso em outras partes da interface
+            userPlanName = subscription.plan_name;
             const limite = subscription.monthly_limit === -1 ? 'Ilimitado' : subscription.monthly_limit;
             const percent = subscription.monthly_limit === -1 ? 0 : Math.min(100, Math.round((subscription.usage / subscription.monthly_limit) * 100));
             planStatusEl.innerHTML = `<div>Plano Atual: ${subscription.plan_name} — Uso este mês: ${subscription.usage} / ${limite} pedidos</div><div class="plan-progress"><div class="plan-progress-bar" style="width:${percent}%"></div></div>`;

--- a/public/style.css
+++ b/public/style.css
@@ -362,6 +362,11 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 #tracking-table tbody tr:last-child td { border-bottom: none; }
 .btn-copy-code { background: none; border: none; cursor: pointer; margin-left: 4px; }
 .btn-verificar { background: none; border: none; color: var(--primary-color); cursor: pointer; text-decoration: underline; }
+.btn-verificar[disabled] {
+    color: #9ca3af;
+    cursor: not-allowed;
+    text-decoration: none;
+}
 .status-badge { padding: 4px 10px; border-radius: 12px; font-size: 0.8rem; font-weight: 600; }
 .status-badge.success { background-color: #dcfce7; color: #166534; }
 .status-badge.error { background-color: #fee2e2; color: #991b1b; }

--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -440,6 +440,13 @@ exports.verificarRastreioManual = async (req, res) => {
     const clienteId = req.user.id;
     const { id } = req.params;
 
+    // Verificação de plano: impede uso para assinaturas gratuitas
+    if (req.subscription && req.subscription.plan_name === 'Grátis') {
+        return res.status(403).json({
+            error: 'Esta funcionalidade não está disponível no plano Grátis. Por favor, faça um upgrade.'
+        });
+    }
+
     try {
         const pedido = await pedidoService.getPedidoById(db, id, clienteId);
         if (!pedido) return res.status(404).json({ error: 'Pedido não encontrado.' });


### PR DESCRIPTION
## Summary
- block manual tracking in the controller if user's plan is `Grátis`
- store user plan name on the client
- disable `Verificar` button for free users
- style disabled button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881724592ac83219141ec5d4aa6a0c9