### PR TITLE
Add city performance reports

### DIFF
--- a/migrations/20250725120000-add-cidade-to-pedidos.js
+++ b/migrations/20250725120000-add-cidade-to-pedidos.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    const table = await queryInterface.describeTable('pedidos');
+    if (!Object.prototype.hasOwnProperty.call(table, 'cidade')) {
+      await queryInterface.addColumn('pedidos', 'cidade', {
+        type: Sequelize.STRING,
+        allowNull: true
+      });
+    }
+  },
+
+  async down (queryInterface, Sequelize) {
+    await queryInterface.removeColumn('pedidos', 'cidade');
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -501,6 +501,16 @@
                             <canvas id="status-pie-chart"></canvas>
                         </div>
                     </div>
+                    <div class="charts-grid">
+                        <div class="chart-container">
+                            <h3>Cidades com Mais Vendas</h3>
+                            <canvas id="cities-sales-chart"></canvas>
+                        </div>
+                        <div class="chart-container">
+                            <h3>Cidades com Mais Cancelamentos</h3>
+                            <canvas id="cities-cancel-chart"></canvas>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/src/app.js
+++ b/src/app.js
@@ -161,6 +161,7 @@ function createExpressApp(db, sessionManager) {
   app.get('/api/reports/summary', planCheck, reportsController.getReportSummary);
   app.get('/api/reports/tracking', planCheck, reportsController.getTrackingReport);
   app.get('/api/reports/clientes-com-rastreio', planCheck, reportsController.getClientesComRastreio);
+  app.get('/api/reports/city-performance', planCheck, reportsController.getCityPerformance);
 
   app.get('/api/logs', planCheck, logsController.listarLogs);
 

--- a/src/controllers/integrationsController.js
+++ b/src/controllers/integrationsController.js
@@ -71,6 +71,7 @@ exports.receberPostback = async (req, res) => {
                     telefone: dados.clientPhone,
                     email: dados.clientEmail,
                     produto: dados.productName,
+                    cidade: dados.clientCity,
                 }, req.venomClient, nossoUsuario.id);
 
                 // AVISA O FRONTEND QUE UM NOVO CONTATO FOI CRIADO

--- a/src/database/database.js
+++ b/src/database/database.js
@@ -86,6 +86,7 @@ function defineModels(sequelize) {
     cliente_id: DataTypes.INTEGER,
     nome: DataTypes.STRING,
     email: DataTypes.STRING,
+    cidade: DataTypes.STRING,
     telefone: { type: DataTypes.STRING, allowNull: false },
     produto: DataTypes.STRING,
     codigoRastreio: DataTypes.STRING,

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -9,6 +9,7 @@ const q = c => DB_CLIENT === 'postgres' ? `"${c}"` : c;
 const ALLOWED_UPDATE_FIELDS = [
     'nome',
     'email',
+    'cidade',
     'telefone',
     'produto',
     'codigoRastreio',
@@ -299,7 +300,7 @@ const marcarComoLido = (db, pedidoId, clienteId = null) => {
  */
 const criarPedido = (db, dadosPedido, client, clienteId = null) => {
     return new Promise(async (resolve, reject) => {
-        const { nome, telefone, email, produto, codigoRastreio, notas } = dadosPedido;
+        const { nome, telefone, email, cidade, produto, codigoRastreio, notas } = dadosPedido;
         const telefoneValidado = normalizeTelefone(telefone);
 
         if (!telefoneValidado || !nome) {
@@ -308,13 +309,13 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
 
         const fotoUrl = await whatsappService.getProfilePicUrl();
 
-        const sql = `INSERT INTO pedidos (cliente_id, nome, email, telefone, produto, ${q('codigoRastreio')}, notas, ${q('fotoPerfilUrl')}, ${q('dataCriacao')}, ${q('lastCheckedAt')}, ${q('statusChangeAt')}, ${q('checkCount')}, ${q('alertSent')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)${DB_CLIENT === 'postgres' ? ' RETURNING id' : ''}`;
-        const params = [clienteId, nome, email || null, telefoneValidado, produto || null, codigoRastreio || null, notas || null, fotoUrl, new Date().toISOString(), null, null, 0, 0];
+        const sql = `INSERT INTO pedidos (cliente_id, nome, email, cidade, telefone, produto, ${q('codigoRastreio')}, notas, ${q('fotoPerfilUrl')}, ${q('dataCriacao')}, ${q('lastCheckedAt')}, ${q('statusChangeAt')}, ${q('checkCount')}, ${q('alertSent')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)${DB_CLIENT === 'postgres' ? ' RETURNING id' : ''}`;
+        const params = [clienteId, nome, email || null, cidade || null, telefoneValidado, produto || null, codigoRastreio || null, notas || null, fotoUrl, new Date().toISOString(), null, null, 0, 0];
 
         db.run(sql, params, function (err) {
             if (err) return reject(err);
             resolve({
-                id: this.lastID, nome, telefone: telefoneValidado, email, produto, codigoRastreio, notas, fotoPerfilUrl: fotoUrl
+                id: this.lastID, nome, telefone: telefoneValidado, email, cidade, produto, codigoRastreio, notas, fotoPerfilUrl: fotoUrl
             });
         });
     });

--- a/src/services/platformMappers.js
+++ b/src/services/platformMappers.js
@@ -7,6 +7,7 @@ function mapHotmart(payload) {
 
     const buyer = payload.buyer || payload.customer || {};
     const telefone = (buyer.phone?.ddd || '') + (buyer.phone?.number || buyer.phone?.local_number || buyer.phone || '');
+    const cidade = buyer.city || buyer.address?.city || payload.client_city || payload.city;
 
     return {
         eventType: evento,
@@ -14,7 +15,8 @@ function mapHotmart(payload) {
         clientEmail: buyer.email,
         clientPhone: telefone,
         productName: payload.product?.name || payload.product_name,
-        trackingCode: payload.tracking_code || payload.purchase?.tracking_code || payload.data?.tracking?.code
+        trackingCode: payload.tracking_code || payload.purchase?.tracking_code || payload.data?.tracking?.code,
+        clientCity: cidade
     };
 }
 
@@ -27,6 +29,7 @@ function mapKiwify(payload) {
 
     const cliente = payload.customer || payload.cliente || {};
     const telefone = (cliente.phone?.ddd || '') + (cliente.phone?.number || cliente.phone || payload.phone || '');
+    const cidade = cliente.city || cliente.address?.city || payload.client_city || payload.city;
 
     return {
         eventType: evento,
@@ -34,7 +37,8 @@ function mapKiwify(payload) {
         clientEmail: cliente.email || payload.email,
         clientPhone: telefone,
         productName: payload.product?.name || payload.product_name || payload.produto,
-        trackingCode: payload.tracking_code || payload.codigo_rastreio
+        trackingCode: payload.tracking_code || payload.codigo_rastreio,
+        clientCity: cidade
     };
 }
 
@@ -48,13 +52,16 @@ function mapBraip(payload) {
         eventType = 'VENDA_CANCELADA';
     }
 
+    const cidade = payload.client_city || payload.city;
+
     return {
         eventType,
         clientEmail: payload.client_email,
         clientName: payload.client_name,
         clientPhone: payload.client_cel,
         productName: payload.product_name,
-        trackingCode: payload.tracking_code
+        trackingCode: payload.tracking_code,
+        clientCity: cidade
     };
 }
 
@@ -67,6 +74,7 @@ function mapGeneric(payload) {
 
     const customer = payload.customer || payload.buyer || {};
     const telefone = (customer.phone?.ddd || '') + (customer.phone?.number || customer.phone || '');
+    const cidade = customer.city || customer.address?.city || payload.client_city || payload.city;
 
     return {
         eventType: evento,
@@ -74,7 +82,8 @@ function mapGeneric(payload) {
         clientEmail: customer.email,
         clientPhone: telefone,
         productName: payload.product?.name || payload.product_name,
-        trackingCode: payload.tracking_code || payload.codigoRastreio || payload.codigo_rastreio
+        trackingCode: payload.tracking_code || payload.codigoRastreio || payload.codigo_rastreio,
+        clientCity: cidade
     };
 }
 


### PR DESCRIPTION
## Summary
- track customers' city in Pedido model
- import city info in webhook mappings and order creation
- add DB migration for the `cidade` column
- expose new `/api/reports/city-performance` endpoint
- show top sales and cancellations by city on the reports page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run migrate` *(fails: sequelize-cli not found)*


------
https://chatgpt.com/codex/tasks/task_e_688215ff55a483219244a0cfa5467179