### PR TITLE
Retrieve real WhatsApp profile picture

### DIFF
--- a/src/controllers/pedidosController.js
+++ b/src/controllers/pedidosController.js
@@ -349,7 +349,7 @@ exports.atualizarFotoDoPedido = async (req, res) => {
             return res.status(404).json({ error: "Pedido não encontrado." });
         }
 
-        const fotoUrl = await whatsappService.getProfilePicUrl();
+        const fotoUrl = await whatsappService.getProfilePicUrl(client, pedido.telefone);
 
         await pedidoService.updateCamposPedido(db, id, { fotoPerfilUrl: fotoUrl }, clienteId);
         req.broadcast(clienteId, { type: 'pedido_atualizado', pedidoId: id });

--- a/src/services/pedidoService.js
+++ b/src/services/pedidoService.js
@@ -307,7 +307,7 @@ const criarPedido = (db, dadosPedido, client, clienteId = null) => {
             return reject(new Error("Nome e um número de celular válido são obrigatórios."));
         }
 
-        const fotoUrl = await whatsappService.getProfilePicUrl();
+        const fotoUrl = await whatsappService.getProfilePicUrl(client, telefoneValidado);
 
         const sql = `INSERT INTO pedidos (cliente_id, nome, email, cidade, telefone, produto, ${q('codigoRastreio')}, notas, ${q('fotoPerfilUrl')}, ${q('dataCriacao')}, ${q('lastCheckedAt')}, ${q('statusChangeAt')}, ${q('checkCount')}, ${q('alertSent')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)${DB_CLIENT === 'postgres' ? ' RETURNING id' : ''}`;
         const params = [clienteId, nome, email || null, cidade || null, telefoneValidado, produto || null, codigoRastreio || null, notas || null, fotoUrl, new Date().toISOString(), null, null, 0, 0];

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -62,11 +62,25 @@ async function sendVideo(client, telefone, videoUrl, caption = '') {
 }
 
 /**
- * Retorna a URL do avatar padrão.
- * A busca pela foto real do contato foi removida.
+ * Obtém a foto de perfil real do contato, retornando uma
+ * imagem padrão caso não seja possível buscar no WhatsApp.
+ *
+ * @param {object} client Instância do venom-bot já autenticada
+ * @param {string} telefone Número do contato em qualquer formato
+ * @returns {string} URL da foto do perfil ou do avatar padrão
  */
-async function getProfilePicUrl() {
-    return DEFAULT_AVATAR_URL;
+async function getProfilePicUrl(client, telefone) {
+    if (!client || !telefone) return DEFAULT_AVATAR_URL;
+
+    try {
+        const numero = normalizeTelefone(telefone);
+        if (!numero) return DEFAULT_AVATAR_URL;
+        const wid = `${numero}@c.us`;
+        const url = await client.getProfilePicFromServer(wid);
+        return url || DEFAULT_AVATAR_URL;
+    } catch (err) {
+        return DEFAULT_AVATAR_URL;
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- fetch profile picture from WhatsApp using the venom client
- store contact's photo when creating a new order
- update controller to refresh the stored photo

## Testing
- `npm test` *(fails: Missing script)*
- `npx -y sequelize-cli db:migrate` *(fails: unable to resolve sequelize package)*

------
https://chatgpt.com/codex/tasks/task_e_68821ad7c1108321abdacc996350e666