### PR TITLE
Implement profile photo fallback

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -619,11 +619,16 @@ const btnEnvioCancelarEl = document.getElementById('btn-envio-cancelar');
 
         // 1. PREENCHER A COLUNA 2: JANELA DE CHAT
         const safeName = escapeHtml(pedido.nome || '');
+        const primeiraLetra = pedido.nome ? pedido.nome.charAt(0).toUpperCase() : '?';
+        const cor = corAvatar(pedido.nome || '');
+        const fotoHtml = pedido.fotoPerfilUrl
+            ? `<img src="${pedido.fotoPerfilUrl}" alt="Foto de ${safeName}" onerror="this.parentElement.innerHTML = '<div class=\\'avatar-fallback\\' style=\\'background-color:${cor};\\'>${primeiraLetra}</div>';">`
+            : `<div class="avatar-fallback" style="background-color:${cor};">${primeiraLetra}</div>`;
         const chatHeaderHtml = `
             <div class="chat-header-main">
                 <div class="contact-info-main">
                     <div class="avatar-container small">
-                        <img src="${pedido.fotoPerfilUrl || 'https://i.imgur.com/z28n3Nz.png'}" alt="Foto de ${safeName}" onerror="this.src='https://i.imgur.com/z28n3Nz.png';">
+                        ${fotoHtml}
                     </div>
                     <h3>${safeName}</h3>
                 </div>

--- a/src/services/whatsappService.js
+++ b/src/services/whatsappService.js
@@ -72,14 +72,14 @@ async function sendVideo(client, telefone, videoUrl, caption = '') {
  * @returns {string} URL ou Base64 da foto do perfil, ou do avatar padrão
  */
 async function getProfilePicUrl(client, telefone, asBase64 = false) {
-    if (!client || !telefone) return DEFAULT_AVATAR_URL;
+    if (!client || !telefone) return null;
 
     try {
         const numero = normalizeTelefone(telefone);
-        if (!numero) return DEFAULT_AVATAR_URL;
+        if (!numero) return null;
         const wid = `${numero}@c.us`;
         const url = await client.getProfilePicFromServer(wid);
-        if (!url) return DEFAULT_AVATAR_URL;
+        if (!url) return null;
 
         if (asBase64) {
             const response = await axios.get(url, { responseType: 'arraybuffer' });
@@ -90,7 +90,7 @@ async function getProfilePicUrl(client, telefone, asBase64 = false) {
 
         return url;
     } catch (err) {
-        return DEFAULT_AVATAR_URL;
+        return null;
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid storing placeholder for missing WhatsApp profile pics
- render coloured fallback avatar in chat header when the profile photo is unavailable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688253c7d7d883219208c0a4d3fd001a