### PR TITLE
Enhance admin dashboard and impersonation

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -12,38 +12,33 @@
         <ul>
             <li><button class="nav-btn active" id="nav-dashboard">Dashboard</button></li>
             <li><button class="nav-btn" id="nav-clients">Clientes</button></li>
-            <li><button class="nav-btn" id="nav-automation">Automações</button></li>
             <li><button class="nav-btn" id="nav-config">Configurações</button></li>
         </ul>
     </nav>
     <div style="margin-left:200px;padding:20px;">
         <section id="view-dashboard">
             <h1>Dashboard</h1>
-            <p>Total de usuários: <span id="total-users">0</span></p>
-            <div id="plans-stats"></div>
-            <p>MRR: R$ <span id="mrr">0</span></p>
+            <div class="dashboard-cards">
+                <div class="dashboard-card">
+                    <h3>Total de Usuários</h3>
+                    <p id="total-users">0</p>
+                </div>
+                <div class="dashboard-card">
+                    <h3>MRR</h3>
+                    <p>R$ <span id="mrr">0</span></p>
+                </div>
+            </div>
+            <div id="plans-stats" class="dashboard-plans"></div>
         </section>
         <section id="view-clients" class="hidden">
             <h1>Gerenciamento de Clientes</h1>
             <button id="btn-new-client" class="btn-primary">Novo Cliente</button>
             <table id="clients-table" style="width:100%;margin-top:20px;border-collapse:collapse;">
                 <thead>
-                    <tr><th>Email</th><th>Ativo</th><th>Requests</th><th>Ações</th></tr>
+                    <tr><th>Email</th><th>Ativo</th><th>Uso do Plano</th><th>Ações</th></tr>
                 </thead>
                 <tbody></tbody>
             </table>
-        </section>
-        <section id="view-automation" class="hidden">
-            <h1>Construtor de Automações</h1>
-            <div id="automation-builder">
-                <div id="steps-container"></div>
-                <div id="add-step-buttons" class="mt-3">
-                    <span>Adicionar novo passo:</span>
-                    <button type="button" class="btn btn-primary btn-add-step" data-step-type="texto">Texto</button>
-                    <button type="button" class="btn btn-info btn-add-step" data-step-type="midia">Mídia</button>
-                    <button type="button" class="btn btn-secondary btn-add-step" data-step-type="arquivo">Arquivo</button>
-                </div>
-            </div>
         </section>
         <section id="view-config" class="hidden">
             <h1>Configurações</h1>

--- a/public/style.css
+++ b/public/style.css
@@ -397,6 +397,39 @@ input:checked ~ .toggle-label { color: var(--success-color); font-weight: 600; }
 .chart-container h3 { margin: 0 0 20px 0; text-align: center; font-size: 1.1rem; }
 @media (max-width: 900px) { .charts-grid { grid-template-columns: 1fr; } }
 
+/* ======== Admin Dashboard ======== */
+.dashboard-cards {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+.dashboard-card {
+  background-color: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 20px;
+  flex: 1;
+  text-align: center;
+}
+.dashboard-card h3 {
+  margin: 0 0 10px 0;
+  color: var(--text-secondary);
+}
+.dashboard-card p {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-color);
+}
+.dashboard-plans {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.dashboard-plans .dashboard-card {
+  flex-basis: 200px;
+}
+
 
 /* --- Estilos para o Layout de Automações (Versão Final com Sanfona) --- */
 

--- a/src/app.js
+++ b/src/app.js
@@ -110,6 +110,7 @@ function createExpressApp(db, sessionManager) {
   app.put('/api/admin/clients/:id/active', adminCheck, adminController.toggleActive);
   app.delete('/api/admin/clients/:id', adminCheck, adminController.deleteClient);
   app.get('/api/admin/stats', adminCheck, adminController.getStats);
+  app.get('/api/admin/login-as/:id', adminCheck, adminController.loginAs);
 
   app.get('/api/subscription', async (req, res) => {
     try {

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -1,5 +1,6 @@
 const userService = require('../services/userService');
 const subscriptionService = require('../services/subscriptionService');
+const jwt = require('jsonwebtoken');
 
 exports.listClients = async (req, res) => {
     try {
@@ -100,6 +101,19 @@ exports.getStats = async (req, res) => {
     } catch (err) {
         console.error('Erro ao coletar métricas:', err);
         res.status(500).json({ error: 'Falha ao coletar métricas' });
+    }
+};
+
+exports.loginAs = async (req, res) => {
+    const id = parseInt(req.params.id);
+    try {
+        const user = await userService.findUserById(req.db, id);
+        if (!user) return res.status(404).json({ error: 'Usuário não encontrado' });
+        const token = jwt.sign({ id: user.id, email: user.email, is_admin: user.is_admin, precisa_trocar_senha: user.precisa_trocar_senha }, process.env.JWT_SECRET, { expiresIn: '12h' });
+        res.json({ token });
+    } catch (err) {
+        console.error('Erro ao gerar token de impersonação:', err);
+        res.status(500).json({ error: 'Falha ao gerar token' });
     }
 };
 


### PR DESCRIPTION
## Summary
- polish admin dashboard with cards
- remove automation tab and related JS
- rename usage column to 'Uso do Plano' and add action buttons
- allow admin to login as a user

## Testing
- `node --check public/admin.js`
- `node --check src/controllers/adminController.js`
- `node --check src/app.js`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688280f82ba4832194e30de0443296a6