### PR TITLE
Improve admin dashboard design

### DIFF
--- a/public/admin.css
+++ b/public/admin.css
@@ -143,3 +143,73 @@ body {
 .btn-salvar {
   background-color: var(--primary-color);
 }
+
+/* Dashboard redesign */
+.page-header {
+  margin-bottom: 20px;
+}
+.page-header h1 {
+  font-size: 2rem;
+  margin-bottom: 5px;
+}
+.page-header p {
+  color: var(--text-secondary);
+}
+
+.stats-grid {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+.stat-card {
+  background-color: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 20px;
+  flex: 1 1 200px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+.stat-icon {
+  width: 40px;
+  height: 40px;
+  background-color: var(--primary-color);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+.stat-info p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+.stat-info h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.card-table {
+  background-color: #ffffff;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 20px;
+}
+.card-table h3 {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+.card-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.card-table th,
+.card-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid var(--border-color);
+}

--- a/public/admin.html
+++ b/public/admin.html
@@ -17,18 +17,41 @@
     </nav>
     <div style="margin-left:200px;padding:20px;">
         <section id="view-dashboard">
-            <h1>Dashboard</h1>
-            <div class="dashboard-cards">
-                <div class="dashboard-card">
-                    <h3>Total de Usuários</h3>
-                    <p id="total-users">0</p>
+            <div class="page-header">
+                <h1>Dashboard do Administrador</h1>
+                <p>Visão geral das métricas da plataforma.</p>
+            </div>
+
+            <div class="stats-grid">
+                <div class="stat-card">
+                    <div class="stat-icon" id="icon-users">👥</div>
+                    <div class="stat-info">
+                        <p>Total de Utilizadores</p>
+                        <h2 id="total-users">0</h2>
+                    </div>
                 </div>
-                <div class="dashboard-card">
-                    <h3>MRR</h3>
-                    <p>R$ <span id="mrr">0</span></p>
+                <div class="stat-card">
+                    <div class="stat-icon" id="icon-mrr">💰</div>
+                    <div class="stat-info">
+                        <p>Receita Mensal (MRR)</p>
+                        <h2>R$ <span id="mrr">0.00</span></h2>
+                    </div>
                 </div>
             </div>
-            <div id="plans-stats" class="dashboard-plans"></div>
+
+            <div class="card-table">
+                <h3>Assinantes por Plano</h3>
+                <table id="plans-stats-table">
+                    <thead>
+                        <tr>
+                            <th>Plano</th>
+                            <th>Assinantes Ativos</th>
+                        </tr>
+                    </thead>
+                    <tbody id="plans-stats-body">
+                    </tbody>
+                </table>
+            </div>
         </section>
         <section id="view-clients" class="hidden">
             <h1>Gerenciamento de Clientes</h1>

--- a/public/admin.js
+++ b/public/admin.js
@@ -66,13 +66,13 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(data => {
                 document.getElementById('total-users').textContent = data.totalUsers;
                 document.getElementById('mrr').textContent = data.mrr.toFixed(2);
-                const plansDiv = document.getElementById('plans-stats');
-                plansDiv.innerHTML = '';
+
+                const plansBody = document.getElementById('plans-stats-body');
+                plansBody.innerHTML = '';
                 data.activeByPlan.forEach(p => {
-                    const card = document.createElement('div');
-                    card.className = 'dashboard-card';
-                    card.innerHTML = `<h3>${p.name}</h3><p>${p.count}</p>`;
-                    plansDiv.appendChild(card);
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `<td>${p.name}</td><td>${p.count}</td>`;
+                    plansBody.appendChild(tr);
                 });
             });
     }


### PR DESCRIPTION
## Summary
- redesign dashboard section with a header, stats cards and plans table
- style new dashboard components
- adapt `fetchStats` to populate redesigned dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68828f50c5d083218fda42a738e965f5