### PR TITLE
Add admin controls for client details

### DIFF
--- a/public/client-details.html
+++ b/public/client-details.html
@@ -19,6 +19,10 @@
                 <div id="subscription-info"></div>
                 <div class="plan-progress"><div class="plan-progress-bar" id="usage-bar"></div></div>
                 <p id="renewal-date"></p>
+                <div style="margin-top:10px; display:flex; gap:10px;">
+                    <button class="btn-primary" id="change-plan-btn">Alterar Plano</button>
+                    <button class="btn-primary" id="adjust-usage-btn">Ajustar Uso</button>
+                </div>
             </div>
         </div>
 
@@ -58,6 +62,16 @@
                     </thead>
                     <tbody></tbody>
                 </table>
+            </div>
+        </div>
+    </div>
+    <div id="plan-modal" class="modal-overlay">
+        <div class="modal-content">
+            <h3>Alterar Plano</h3>
+            <select id="plan-select"></select>
+            <div class="modal-acoes" style="margin-top:10px;">
+                <button type="button" class="btn-cancelar" id="plan-cancel">Cancelar</button>
+                <button type="button" class="btn-salvar" id="plan-save">Salvar</button>
             </div>
         </div>
     </div>

--- a/src/app.js
+++ b/src/app.js
@@ -109,6 +109,7 @@ function createExpressApp(db, sessionManager) {
   app.post('/api/admin/clients', adminCheck, adminController.createClient);
   app.put('/api/admin/clients/:id', adminCheck, adminController.updateClient);
   app.put('/api/admin/clients/:id/active', adminCheck, adminController.toggleActive);
+  app.put('/api/admin/clients/:id/usage', adminCheck, adminController.setUsage);
   app.delete('/api/admin/clients/:id', adminCheck, adminController.deleteClient);
   app.get('/api/admin/stats', adminCheck, adminController.getStats);
   app.get('/api/admin/login-as/:id', adminCheck, adminController.loginAs);

--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -155,3 +155,18 @@ exports.getClientDetails = async (req, res) => {
     }
 };
 
+exports.setUsage = async (req, res) => {
+    const id = parseInt(req.params.id);
+    const { usage } = req.body;
+    if (usage === undefined || isNaN(parseInt(usage))) {
+        return res.status(400).json({ error: 'Valor de uso inválido' });
+    }
+    try {
+        await subscriptionService.setUsage(req.db, id, parseInt(usage));
+        res.json({ message: 'Uso ajustado' });
+    } catch (err) {
+        console.error('Erro ao ajustar uso:', err);
+        res.status(500).json({ error: 'Falha ao ajustar uso' });
+    }
+};
+

--- a/src/services/subscriptionService.js
+++ b/src/services/subscriptionService.js
@@ -120,6 +120,15 @@ function decrementUsage(db, subscriptionId) {
     });
 }
 
+function setUsage(db, userId, usage) {
+    return new Promise((resolve, reject) => {
+        db.run('UPDATE subscriptions SET usage = ? WHERE user_id = ?', [usage, userId], function(err) {
+            if (err) return reject(err);
+            resolve({ changes: this.changes });
+        });
+    });
+}
+
 module.exports = {
     getUserSubscription,
     incrementUsage,
@@ -128,5 +137,6 @@ module.exports = {
     updateUserPlan,
     updateSubscriptionStatus,
     decrementUsage,
+    setUsage,
 };
 


### PR DESCRIPTION
## Summary
- show subscription price and limit in client details
- add buttons to change plan and adjust usage
- implement admin API to update usage
- expose new `/api/admin/clients/:id/usage` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68837f8cd3f083219f5a790c620aeb0e